### PR TITLE
feat(accounts): extend accounts configuration with universal path

### DIFF
--- a/manifests/kcp/workspace-type-account.yaml
+++ b/manifests/kcp/workspace-type-account.yaml
@@ -23,3 +23,7 @@ spec:
         path: root
       - name: account
         path: root
+  extend:
+    with:
+      - name: universal
+        path: root


### PR DESCRIPTION
This PR changes the account workspacetype to extend from the root universal type. 

This leads to the default namespace to be created by default in a newly created workspace using this type