### PR TITLE
fix: improve host URL construction for provider connection

### DIFF
--- a/pkg/subroutines/providersecret.go
+++ b/pkg/subroutines/providersecret.go
@@ -227,11 +227,16 @@ func (r *ProvidersecretSubroutine) HandleProviderConnection(
 	}
 
 	newConfig := rest.CopyConfig(cfg)
+	hostPort := fmt.Sprintf("https://%s-front-proxy.%s:%s", operatorCfg.KCP.FrontProxyName, operatorCfg.KCP.Namespace, operatorCfg.KCP.FrontProxyPort)
 	if pc.External {
-		newConfig.Host = fmt.Sprintf("https://kcp.api.%s:%d/%s", instance.Spec.Exposure.BaseDomain, instance.Spec.Exposure.Port, address.Path)
-	} else {
-		newConfig.Host = fmt.Sprintf("https://%s-front-proxy.%s:%s/%s", operatorCfg.KCP.FrontProxyName, operatorCfg.KCP.Namespace, operatorCfg.KCP.FrontProxyPort, address.Path)
+		hostPort = fmt.Sprintf("https://kcp.api.%s:%d", instance.Spec.Exposure.BaseDomain, instance.Spec.Exposure.Port)
 	}
+	host, err := url.JoinPath(hostPort, address.Path)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to join path for provider connection")
+		return ctrl.Result{}, errors.NewOperatorError(err, false, false)
+	}
+	newConfig.Host = host
 
 	apiConfig := restConfigToAPIConfig(newConfig)
 	kcpConfigBytes, err := clientcmd.Write(*apiConfig)


### PR DESCRIPTION
## Summary

- Fixed URL construction for provider connections by using `url.JoinPath` instead of manual string concatenation
- Properly handles path joining to avoid issues with multiple slashes and malformed URLs
- Added error handling for path joining operations
- Simplified logic by extracting host+port construction before path joining

This ensures kubeconfig URLs are correctly formed for both external and internal provider connections.