### PR TITLE
fix: add conditional expression for email claim based on feature toggle

### DIFF
--- a/manifests/kcp/workspace-authentication-configuration.yaml
+++ b/manifests/kcp/workspace-authentication-configuration.yaml
@@ -18,8 +18,12 @@ spec:
           claim: groups
           prefix: ""
         username:
+      {{- if eq .featureDisableEmailVerification "true" }}
+          expression: claims.email
+      {{- else }}
           claim: email
           prefix: ""
+      {{- end }}
       {{- if eq .featureDisableEmailVerification "true" }}
       claimValidationRules:
         - expression: "claims.?email_verified.orValue(true) == true || claims.?email_verified.orValue(true) == false"


### PR DESCRIPTION
## Summary

- Updated workspace authentication configuration to use expression-based email claim when email verification is disabled
- Changes the username claim handling from a simple `claim: email` to a conditional expression `claims.email` when the feature toggle `featureDisableEmailVerification` is set to "true"

This ensures proper authentication behavior when email verification is disabled while maintaining backward compatibility when it's enabled.