### PR TITLE
feat: add feature toggle to disable loading ContentConfiguration manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ spec:
 | `feature-enable-marketplace-org` | Applies the ContentConfiguration resources for the Marketplace feature at the organization level |
 | `feature-accounts-in-accounts` | Applies the ContentConfiguration resources for displaying accounts within the account context |
 | `feature-disable-email-verification` | Disables email verification requirement in WorkspaceAuthenticationConfiguration |
+| `feature-disable-contentconfigurations` | Disables loading of all ContentConfiguration manifests during KCP setup |
 
 #### Example Usage
 

--- a/pkg/subroutines/kcpsetup.go
+++ b/pkg/subroutines/kcpsetup.go
@@ -162,6 +162,7 @@ func (r *KcpsetupSubroutine) createKcpResources(ctx context.Context, config *res
 	templateData["port"] = fmt.Sprintf("%d", port)
 	templateData["protocol"] = protocol
 	templateData["featureDisableEmailVerification"] = HasFeatureToggle(inst, "feature-disable-email-verification")
+	templateData["featureDisableContentConfigurations"] = HasFeatureToggle(inst, "feature-disable-contentconfigurations")
 
 	err = ApplyDirStructure(ctx, dir, "root", config, templateData, inst, r.kcpHelper)
 	if err != nil {

--- a/pkg/subroutines/subroutine_helpers.go
+++ b/pkg/subroutines/subroutine_helpers.go
@@ -448,6 +448,14 @@ func ApplyManifestFromFile(
 		return nil
 	}
 
+	if obj.GetKind() == "ContentConfiguration" && obj.GetAPIVersion() == "ui.platform-mesh.io/v1alpha1" {
+		if templateData["featureDisableContentConfigurations"] == "true" {
+			log.Debug().Str("file", path).Str("kind", obj.GetKind()).Str("name", obj.GetName()).
+				Msg("Skipping ContentConfiguration due to feature-disable-contentconfigurations toggle")
+			return nil
+		}
+	}
+
 	if obj.GetKind() == "WorkspaceType" && obj.GetAPIVersion() == "tenancy.kcp.io/v1alpha1" {
 		extraDefaultApiBindings := getExtraDefaultApiBindings(obj, wsPath, inst)
 		currentDefAPiBindings, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaultAPIBindings")


### PR DESCRIPTION
## Summary

- Adds `feature-disable-contentconfigurations` feature toggle that prevents loading of ContentConfiguration manifests during KCP setup
- When enabled, all 6 ContentConfiguration files in `manifests/kcp/01-platform-mesh-system/` are skipped
- Follows existing feature toggle pattern used by `feature-disable-email-verification`

## Changes

- `pkg/subroutines/kcpsetup.go`: Add toggle value to templateData
- `pkg/subroutines/subroutine_helpers.go`: Add skip logic in `ApplyManifestFromFile()` for ContentConfiguration kind
- `pkg/subroutines/kcpsetup_test.go`: Add unit tests for the new behavior
- `README.md`: Document the new feature toggle

## Usage

```yaml
spec:
  featureToggles:
    - name: "feature-disable-contentconfigurations"
```