### PR TITLE
feat: update account API resource schema to new version and refine descriptions

### DIFF
--- a/manifests/kcp/01-platform-mesh-system/apiexport-core.platform-mesh.io.yaml
+++ b/manifests/kcp/01-platform-mesh-system/apiexport-core.platform-mesh.io.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   latestResourceSchemas:
   - v250715-5b899f6.accountinfos.core.platform-mesh.io
-  - v250715-5b899f6.accounts.core.platform-mesh.io
+  - v260109-82344be.accounts.core.platform-mesh.io
   - v250704-6d57f16.contentconfigurations.ui.platform-mesh.io
   - v250725-732d200.providermetadatas.ui.platform-mesh.io
   - v250718-a64f278.authorizationmodels.core.platform-mesh.io

--- a/manifests/kcp/01-platform-mesh-system/apiresourceschema-accounts.core.platform-mesh.io.yaml
+++ b/manifests/kcp/01-platform-mesh-system/apiresourceschema-accounts.core.platform-mesh.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v250715-5b899f6.accounts.core.platform-mesh.io
+  name: v260109-82344be.accounts.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io
   names:
@@ -93,9 +93,6 @@ spec:
               type: array
             type:
               description: Type specifies the intended type for this Account object.
-              enum:
-              - org
-              - account
               type: string
           required:
           - displayName
@@ -106,16 +103,8 @@ spec:
           properties:
             conditions:
               items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource.\n---\nThis struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,\n\n\n\ttype
-                  FooStatus struct{\n\t    // Represents the observations of a foo's
-                  current state.\n\t    // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t
-                  \   // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t
-                  \   Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                  \   // other fields\n\t}"
+                description: Condition contains details for one aspect of the current
+                  state of this API Resource.
                 properties:
                   lastTransitionTime:
                     description: |-
@@ -156,12 +145,7 @@ spec:
                     - Unknown
                     type: string
                   type:
-                    description: |-
-                      type of condition in CamelCase or in foo.example.com/CamelCase.
-                      ---
-                      Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                      useful (see .node.status.conditions), the ability to deconflict is important.
-                      The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
                     maxLength: 316
                     pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                     type: string


### PR DESCRIPTION
This updates the account resource schema and removes CRD based enum validation as this will be done via webhook in the future