### PR TITLE
fix: update marketplace URLs to use subdomains for organization context

### DIFF
--- a/manifests/features/feature-enable-marketplace-account/01-platform-mesh-system/contentconfiguration-account-marketplace.yaml
+++ b/manifests/features/feature-enable-marketplace-account/01-platform-mesh-system/contentconfiguration-account-marketplace.yaml
@@ -18,7 +18,7 @@ spec:
                 "order": 700,
                 "label": "Marketplace",
                 "icon": "retail-store",
-                "url": "https://{{ .baseDomainPort }}/ui/marketplace/ui/#/entity/:accountId/marketplace",
+                "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/entity/:accountId/marketplace",
                 "viewGroup": "marketplace",
                 "context": {
                   "accountId": ":core_platform-mesh_io_accountId"
@@ -33,7 +33,7 @@ spec:
                   {
                     "pathSegment": ":providerName",
                     "hideFromNav": true,
-                    "url": "https://{{ .baseDomainPort }}/ui/marketplace/ui/#/provider/:providerName",
+                    "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/provider/:providerName",
                     "context": {
                       "providerName": ":providerName",
                       "accountId": ":core_platform-mesh_io_accountId"

--- a/manifests/features/feature-enable-marketplace-org/01-platform-mesh-system/contentconfiguration-main-marketplace.yaml
+++ b/manifests/features/feature-enable-marketplace-org/01-platform-mesh-system/contentconfiguration-main-marketplace.yaml
@@ -19,7 +19,7 @@ spec:
                 "order": 700,
                 "icon": "retail-store",
                 "hideFromNav": false,
-                "url": "https://{{ .baseDomainPort }}/ui/marketplace/ui/#/entity/org/marketplace",
+                "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/entity/org/marketplace",
                 "viewGroup": "marketplace",
                 "context": {
                   "entityContext": {
@@ -38,7 +38,7 @@ spec:
                   {
                     "pathSegment": ":providerName",
                     "hideFromNav": true,
-                    "url": "https://{{ .baseDomainPort }}/ui/marketplace/ui/#/provider/:providerName",
+                    "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/provider/:providerName",
                     "context": {
                       "providerName": ":providerName"
                     }


### PR DESCRIPTION
## Summary
- Update marketplace URLs to include organization subdomain (`{context.organization}.`) for proper organization-scoped routing
- Affects both account-level and org-level marketplace content configurations