### PR TITLE
fix: add frameContext placeholder to prevent console error in marketplace

### DIFF
--- a/manifests/features/feature-enable-marketplace-account/01-platform-mesh-system/contentconfiguration-account-marketplace.yaml
+++ b/manifests/features/feature-enable-marketplace-account/01-platform-mesh-system/contentconfiguration-account-marketplace.yaml
@@ -21,7 +21,8 @@ spec:
                 "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/entity/:accountId/marketplace",
                 "viewGroup": "marketplace",
                 "context": {
-                  "accountId": ":core_platform-mesh_io_accountId"
+                  "accountId": ":core_platform-mesh_io_accountId",
+                  "frameContext": {"automaticDGraphqlApiUrl": "http://localhost/placeholder"}
                 }
               },
               {
@@ -36,7 +37,8 @@ spec:
                     "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/provider/:providerName",
                     "context": {
                       "providerName": ":providerName",
-                      "accountId": ":core_platform-mesh_io_accountId"
+                      "accountId": ":core_platform-mesh_io_accountId",
+                      "frameContext": {"automaticDGraphqlApiUrl": "http://localhost/placeholder"}
                     }
                   }
                 ]

--- a/manifests/features/feature-enable-marketplace-org/01-platform-mesh-system/contentconfiguration-main-marketplace.yaml
+++ b/manifests/features/feature-enable-marketplace-org/01-platform-mesh-system/contentconfiguration-main-marketplace.yaml
@@ -22,6 +22,7 @@ spec:
                 "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/entity/org/marketplace",
                 "viewGroup": "marketplace",
                 "context": {
+                  "frameContext": {"automaticDGraphqlApiUrl": "http://localhost/placeholder"},
                   "entityContext": {
                     "account": {
                       "policies": ["providerAdmin", "projectAdmin", "projectMember"]
@@ -40,6 +41,7 @@ spec:
                     "hideFromNav": true,
                     "url": "https://{context.organization}.{{ .baseDomainPort }}/ui/marketplace/ui/#/provider/:providerName",
                     "context": {
+                      "frameContext": {"automaticDGraphqlApiUrl": "http://localhost/placeholder"},
                       "providerName": ":providerName"
                     }
                   }


### PR DESCRIPTION
## Summary

- Add `frameContext.automaticDGraphqlApiUrl` placeholder to marketplace content configurations
- This setting is expected by an underlying library but not used; providing a placeholder prevents a visible error in the browser console
- Applied to both account-level and organization-level marketplace configurations