### PR TITLE
feat(operator): generate Root KCP URL for rebac-authz-webhook kubeconfig

### DIFF
--- a/pkg/subroutines/defaults.go
+++ b/pkg/subroutines/defaults.go
@@ -21,9 +21,8 @@ var DefaultProviderConnections = []corev1alpha1.ProviderConnection{
 		Secret:            "account-operator-kubeconfig",
 	},
 	{
-		EndpointSliceName: ptr.To("core.platform-mesh.io"),
-		Path:              "root:platform-mesh-system",
-		Secret:            "rebac-authz-webhook-kubeconfig",
+		Path:   "root:platform-mesh-system",
+		Secret: "rebac-authz-webhook-kubeconfig",
 	},
 	{
 		Path:   "root:platform-mesh-system",


### PR DESCRIPTION
## Summary

Updates platform-mesh-operator to generate Root KCP API Server URL (instead of Virtual Workspace URL) for rebac-authz-webhook kubeconfig secret. This enables API Server Discovery which is required for the webhook to discover APIExportEndpointSlice resources.

## Changes

### Defaults
- Remove EndpointSliceName from rebac-authz-webhook ProviderConnection
- Operator now generates Root KCP URL: https://frontproxy.../clusters/root:platform-mesh-system
- Previously generated Virtual Workspace URL which doesn't support API Server Discovery

## Why

The rebac-authz-webhook uses cache.New() which requires API Server Discovery to discover APIExportEndpointSlice resources. Virtual Workspace URLs don't support API Server Discovery for root KCP CRDs. By removing EndpointSliceName, the operator generates a Root KCP URL which supports API Discovery.

## Testing

- Operator generates kubeconfig secret with Root KCP URL
- Webhook can successfully discover APIExportEndpointSlice resources
- Webhook pod starts and functions correctly