### PR TITLE
fix: improve namespace content configuration

### DIFF
--- a/manifests/kcp/01-platform-mesh-system/contentconfiguration-account-namespace.yaml
+++ b/manifests/kcp/01-platform-mesh-system/contentconfiguration-account-namespace.yaml
@@ -14,8 +14,8 @@ spec:
               "data": {
                   "nodes": [
                       {
-                          "pathSegment": "core_namespaces",
-                          "navigationContext": "core_namespaces",
+                          "pathSegment": "namespaces",
+                          "navigationContext": "namespaces",
                           "label": "Namespaces",
                           "entityType": "main.core_platform-mesh_io_account",
                           "icon": "group-2",
@@ -82,7 +82,7 @@ spec:
                                     "graphqlEntity": {
                                         "version": "v1",
                                         "kind": "Namespace",
-                                        "query": "{ metadata { name deletionTimestamp} }",
+                                        "query": "{ metadata { name deletionTimestamp} }"
                                     }
                                 },
                                 "context": {


### PR DESCRIPTION
## Summary

- Update navigation path segments from `core_namespaces` to `namespaces` for improved clarity and consistency
- Remove trailing comma in GraphQL query metadata field