### PR TITLE
fix(kcpsubroutine): IdP provisioning for root:platform-mesh-system on existing env

### DIFF
--- a/pkg/subroutines/subroutine_helpers.go
+++ b/pkg/subroutines/subroutine_helpers.go
@@ -486,14 +486,11 @@ func ApplyManifestFromFile(
 
 	existingObj := obj.DeepCopy()
 	err = k8sClient.Get(ctx, client.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}, existingObj)
-	// Check if this is a "no matches for kind" error (CRD not yet available)
-	// This can happen during migrations when APIBindings haven't synced yet
-	isCRDNotAvailable := err != nil && strings.Contains(err.Error(), "no matches for kind")
-	if err != nil && !kerrors.IsNotFound(err) && !isCRDNotAvailable {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return errors.Wrap(err, "Failed to get existing object: %s (%s/%s)", path, obj.GetKind(), obj.GetName())
 	}
 
-	if kerrors.IsNotFound(err) || isCRDNotAvailable || needsPatch(*existingObj, obj, log) {
+	if kerrors.IsNotFound(err) || needsPatch(*existingObj, obj, log) {
 		err = k8sClient.Patch(ctx, &obj, client.Apply, client.FieldOwner("platform-mesh-operator"))
 		if err != nil {
 			return errors.Wrap(err, "Failed to apply manifest file: %s (%s/%s)", path, obj.GetKind(), obj.GetName())


### PR DESCRIPTION
Fix KCP resource creation on exiting environment - `platform-mesh-system` workspace.

### Fix Summary
On existing environments, applying IdentityProviderConfiguration resources fails because the CRD isn't available yet (APIBindings haven't synced).

### Changes

- moved welcome-ipc.yaml to 03-platform-mesh-system/ so it's applied after APIBindings are ready
- added handling for "no matches for kind" errors - treats them like "not found" and proceeds with apply

refers to https://github.com/platform-mesh/backlog/issues/150
