### PR TITLE
fix: add ForceOwnership to Server-Side Apply calls

### DIFF
--- a/pkg/subroutines/deployment.go
+++ b/pkg/subroutines/deployment.go
@@ -454,7 +454,7 @@ func applyManifestFromFileWithMergedValues(ctx context.Context, path string, k8s
 		return err
 	}
 
-	err = k8sClient.Patch(ctx, &obj, client.Apply, client.FieldOwner("platform-mesh-operator"))
+	err = k8sClient.Patch(ctx, &obj, client.Apply, client.FieldOwner("platform-mesh-operator"), client.ForceOwnership)
 	if err != nil {
 		return errors.Wrap(err, "Failed to apply manifest file: %s (%s/%s)", path, obj.GetKind(), obj.GetName())
 	}
@@ -470,7 +470,7 @@ func applyReleaseWithValues(ctx context.Context, path string, k8sClient client.C
 	}
 	obj.Object["spec"].(map[string]interface{})["values"] = values
 
-	err = k8sClient.Patch(ctx, &obj, client.Apply, client.FieldOwner("platform-mesh-operator"))
+	err = k8sClient.Patch(ctx, &obj, client.Apply, client.FieldOwner("platform-mesh-operator"), client.ForceOwnership)
 	if err != nil {
 		return errors.Wrap(err, "Failed to apply manifest file: %s (%s/%s)", path, obj.GetKind(), obj.GetName())
 	}

--- a/pkg/subroutines/deployment_test.go
+++ b/pkg/subroutines/deployment_test.go
@@ -64,7 +64,7 @@ func (s *DeployTestSuite) Test_applyReleaseWithValues() {
 
 	// mocks
 	s.clientMock.EXPECT().Get(mock.Anything, types.NamespacedName{Namespace: "default", Name: "rebac-authz-webhook-cert"}, mock.Anything).Return(nil).Twice()
-	s.clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+	s.clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 			// Simulate a successful patch operation
 			hr := obj.(*unstructured.Unstructured)
@@ -118,7 +118,7 @@ func (s *DeployTestSuite) Test_applyReleaseWithValues() {
 	templateVars, err = subroutines.TemplateVars(ctx, inst, s.clientMock)
 	s.Assert().NoError(err, "TemplateVars should not return an error")
 
-	s.clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+	s.clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 			// Simulate a successful patch operation
 			hr := obj.(*unstructured.Unstructured)

--- a/pkg/subroutines/featuretoggles_test.go
+++ b/pkg/subroutines/featuretoggles_test.go
@@ -108,7 +108,7 @@ func (s *FeaturesTestSuite) TestProcess() {
 		})
 
 	// Expect multiple Patch calls for applying manifests (flexible count)
-	mockKcpClient.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockKcpClient.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Mock workspace lookups and patch calls
 	mockKcpClient.EXPECT().

--- a/pkg/subroutines/kcpsetup_test.go
+++ b/pkg/subroutines/kcpsetup_test.go
@@ -87,7 +87,7 @@ func (s *KcpsetupTestSuite) Test_applyDirStructure() {
 	}
 
 	// Expect multiple Patch calls for applying manifests (flexible count)
-	kcpClientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	kcpClientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Mock unstructured object lookups (for general manifest objects - flexible count)
 	kcpClientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
@@ -464,7 +464,7 @@ func (s *KcpsetupTestSuite) TestProcess() {
 
 	// Mock patch calls for applying manifests (flexible count)
 	mockKcpClient.EXPECT().
-		Patch(mock.Anything, mock.AnythingOfType("*unstructured.Unstructured"), mock.Anything, mock.Anything).
+		Patch(mock.Anything, mock.AnythingOfType("*unstructured.Unstructured"), mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
 	// Call Process
@@ -668,7 +668,7 @@ func (s *KcpsetupTestSuite) TestCreateWorkspaces() {
 		})
 
 	// Mock patch calls for applying manifests (flexible count)
-	mockKcpClient.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockKcpClient.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	err = s.testObj.CreateKcpResources(context.Background(), &rest.Config{}, ManifestStructureTest, &corev1alpha1.PlatformMesh{})
 	s.Assert().Nil(err)
 
@@ -733,7 +733,7 @@ func (s *KcpsetupTestSuite) TestCreateWorkspaces() {
 		})
 
 	// Mock patch calls for applying manifests (flexible count) - but they should fail
-	mockKcpClient.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("patch failed"))
+	mockKcpClient.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("patch failed"))
 	err = s.testObj.CreateKcpResources(context.Background(), &rest.Config{}, ManifestStructureTest, &corev1alpha1.PlatformMesh{})
 	s.Assert().Error(err)
 	s.Assert().Contains(err.Error(), "Failed to apply")
@@ -792,13 +792,9 @@ func (s *KcpsetupTestSuite) Test_ApplyExtraWorkspaces_Success() {
 		NewKcpClient(mock.Anything, parentPath).
 		Return(kcpClientMock, nil).Once()
 
-	// First Get => NotFound (so Patch executed)
+	// SSA Patch - no Get needed
 	kcpClientMock.EXPECT().
-		Get(mock.Anything, types.NamespacedName{Name: "extra-ws"}, mock.AnythingOfType("*unstructured.Unstructured")).
-		Return(apierrors.NewNotFound(schema.GroupResource{Group: "tenancy.kcp.io", Resource: "workspaces"}, "extra-ws")).Once()
-
-	kcpClientMock.EXPECT().
-		Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Once()
 
 	inst := s.newPlatformMeshWithExtraWorkspaces([]extraWsDef{
@@ -855,12 +851,9 @@ func (s *KcpsetupTestSuite) Test_ApplyExtraWorkspaces_Patch_Error() {
 		NewKcpClient(mock.Anything, parentPath).
 		Return(kcpClientMock, nil).Once()
 
+	// SSA Patch fails - no Get needed
 	kcpClientMock.EXPECT().
-		Get(mock.Anything, types.NamespacedName{Name: "ws3"}, mock.AnythingOfType("*unstructured.Unstructured")).
-		Return(apierrors.NewNotFound(schema.GroupResource{Group: "tenancy.kcp.io", Resource: "workspaces"}, "ws3")).Once()
-
-	kcpClientMock.EXPECT().
-		Patch(mock.Anything, mock.AnythingOfType("*unstructured.Unstructured"), mock.Anything, mock.Anything).
+		Patch(mock.Anything, mock.AnythingOfType("*unstructured.Unstructured"), mock.Anything, mock.Anything, mock.Anything).
 		Return(errors.New("patch failed")).Once()
 
 	inst := s.newPlatformMeshWithExtraWorkspaces([]extraWsDef{
@@ -1054,7 +1047,7 @@ func (s *KcpsetupTestSuite) Test_ApplyManifestFromFile_SkipsContentConfiguration
 			} else {
 				kcpClientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
 					Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Once()
-				kcpClientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+				kcpClientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 				err := subroutines.ApplyManifestFromFile(ctx, path, kcpClientMock, templateData, "root:platform-mesh-system", &corev1alpha1.PlatformMesh{})
 				s.Assert().NoError(err)
@@ -1078,7 +1071,7 @@ func (s *KcpsetupTestSuite) Test_ApplyManifestFromFile_DoesNotSkipNonContentConf
 	// Even with toggle enabled, non-ContentConfiguration files should be applied
 	kcpClientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
 		Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Once()
-	kcpClientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	kcpClientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	err := subroutines.ApplyManifestFromFile(ctx, path, kcpClientMock, templateData, "root", &corev1alpha1.PlatformMesh{})
 	s.Assert().NoError(err)

--- a/pkg/subroutines/subroutine_helpers_test.go
+++ b/pkg/subroutines/subroutine_helpers_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines/mocks"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type HelperTestSuite struct {
@@ -299,10 +297,8 @@ func (s *HelperTestSuite) TestConstructorOK() {
 func (s *HelperTestSuite) TestApplyManifestFromFile() {
 
 	cl := new(mocks.Client)
-	// Mock Get to return NotFound error (which should trigger a Patch)
-	cl.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
-		Return(&apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).Once()
-	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	// SSA Patch call (no Get needed)
+	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	err := subroutines.ApplyManifestFromFile(context.TODO(), "../../manifests/kcp/workspace-platform-mesh-system.yaml", cl, make(map[string]any), "root:platform-mesh-system", &corev1alpha1.PlatformMesh{})
 	s.Assert().Nil(err)
 
@@ -312,21 +308,15 @@ func (s *HelperTestSuite) TestApplyManifestFromFile() {
 	err = subroutines.ApplyManifestFromFile(context.TODO(), "./kcpsetup.go", nil, make(map[string]any), "root:platform-mesh-system", &corev1alpha1.PlatformMesh{})
 	s.Assert().Error(err)
 
-	cl.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
-		Return(&apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).Once()
-	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("error")).Once()
+	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("error")).Once()
 	err = subroutines.ApplyManifestFromFile(context.TODO(), "../../manifests/kcp/workspace-platform-mesh-system.yaml", cl, make(map[string]any), "root:platform-mesh-system", &corev1alpha1.PlatformMesh{})
 	s.Assert().Error(err)
 
-	cl.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
-		Return(&apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).Once()
-	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	err = subroutines.ApplyManifestFromFile(context.TODO(), "../../manifests/kcp/workspace-orgs.yaml", cl, make(map[string]any), "root:orgs", &corev1alpha1.PlatformMesh{})
 	s.Assert().Nil(err)
 
-	cl.EXPECT().Get(mock.Anything, mock.Anything, mock.AnythingOfType("*unstructured.Unstructured")).
-		Return(&apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).Once()
-	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	cl.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	templateData := map[string]any{
 		".account-operator.webhooks.platform-mesh.io.ca-bundle": "CABundle",
 	}


### PR DESCRIPTION
## Summary

- Add `client.ForceOwnership` to all Server-Side Apply (SSA) Patch calls to prevent field management conflicts when other controllers (FluxCD, cert-manager, KCP controllers) also modify the same resources
- Remove the `needsPatch` optimization which was skipping patches unnecessarily and could miss ownership updates (SSA is already idempotent, the API server handles no-op cases efficiently)
- Remove unnecessary `Get` call before `Patch` in `ApplyManifestFromFile`

### Files Changed

| File | Changes |
|------|---------|
| `pkg/subroutines/deployment.go` | Add ForceOwnership to `applyManifestFromFileWithMergedValues` and `applyReleaseWithValues` |
| `pkg/subroutines/kcpsetup.go` | Add ForceOwnership to `applyExtraWorkspaces`, remove unused `needsPatch` function |
| `pkg/subroutines/subroutine_helpers.go` | Refactor `ApplyManifestFromFile` to use ForceOwnership and remove Get+needsPatch check |
| `*_test.go` | Update mock expectations to include the additional ForceOwnership option |