### PR TITLE
chore: standardize repository files

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,4 +309,4 @@ Please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository f
 
 ## Code of Conduct
 
-Please refer to the [CODE_OF_CONDUCT.md](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md) file in this repository information on the expected Code of Conduct for contributing to Platform Mesh.
+Please refer to our [Code of Conduct](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md) for information on the expected conduct for contributing to Platform Mesh.


### PR DESCRIPTION
## Summary

- Removed `## Licensing` section (SAP SE copyright) from README
- Updated CODE_OF_CONDUCT link to point to [central .github repository](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md)

## Context

Repository governance files are being centralized in [platform-mesh/.github](https://github.com/platform-mesh/.github).