### PR TITLE
docs: add BMWK-EU funding notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,3 +310,5 @@ Please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository f
 ## Code of Conduct
 
 Please refer to our [Code of Conduct](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md) for information on the expected conduct for contributing to Platform Mesh.
+
+<p align="center"><img alt="Bundesministerium für Wirtschaft und Energie (BMWE)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>


### PR DESCRIPTION
## Summary

- Adds the required BMWK-EU funding logo/notice to the end of the README, as required for all public repositories in the organization.