### PR TITLE
chore: update gateway kubeconfig

### DIFF
--- a/pkg/subroutines/defaults.go
+++ b/pkg/subroutines/defaults.go
@@ -36,7 +36,7 @@ var DefaultProviderConnections = []corev1alpha1.ProviderConnection{
 	},
 	{
 		Path:              "root:platform-mesh-system",
-		Secret:            "kubernetes-graphql-gateway-kubeconfig",
+		Secret:            "kubernetes-grapqhl-gateway-kubeconfig",
 		AdminAuth:         ptr.To(true),
 	},
 	{

--- a/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
+++ b/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
@@ -1,38 +1,34 @@
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
+kind: HelmRepository
 metadata:
   name: ocm-k8s-toolkit
   namespace: default
 spec:
-  interval: 1m
-  url: https://github.com/open-component-model/open-component-model
-  ref:
-    commit: 0c8ad3c6f96172bd0b7c3e5385c4f859ad4e7043
+  type: oci
+  interval: 5m
+  url: oci://ghcr.io/open-component-model/kubernetes/controller
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
+
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
 metadata:
   name: ocm-k8s-toolkit
   namespace: default
 spec:
+  releaseName: ocm-k8s-toolkit
   interval: 1m
+  timeout: 15m
   targetNamespace: ocm-system
-  sourceRef:
-    kind: GitRepository
-    name: ocm-k8s-toolkit
-  path: ./kubernetes/controller/config/default
-  prune: true
-  patches:
-    - patch: |
-        - op: replace
-          path: /spec/template/spec/containers/0/args
-          value:
-            - --health-probe-bind-address=:8081
-            - --resource-controller-concurrency=21
-            - --zap-log-level=4
-        - op: replace
-          path: /spec/template/spec/containers/0/image
-          value: ghcr.io/open-component-model/kubernetes/controller@sha256:5e790dad020adcfd0793f249d177a28429ef22446def39c9286eab90c52175c1
-      target:
-        kind: Deployment
-        name: controller-manager
+  chart:
+    spec:
+      chart: chart
+      version: "0.2.0"
+      sourceRef:
+        kind: HelmRepository
+        name: ocm-k8s-toolkit
+  values:
+    manager:
+      concurrency:
+        resource: 21
+      logging:
+        level: "4"

--- a/test/e2e/kind/kustomize/components/ocm/component.yaml
+++ b/test/e2e/kind/kustomize/components/ocm/component.yaml
@@ -14,4 +14,4 @@ spec:
       namespace: default
   repositoryRef:
     name: platform-mesh
-  semver:  0.3.0-build.806
+  semver:  0.3.0-build.808


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

This pr makes gateway's kubeconfig use `:root:platform-mesh-system` as a host instead of vm url