### PR TITLE
fix: align CRD printer columns and resource subroutine with new condition types

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,7 +71,7 @@ tasks:
     cmds:
       - |
         export PATH=$(pwd)/{{.LOCAL_BIN}}:$PATH
-        go test -timeout 10m -coverprofile=cover.out github.com/platform-mesh/platform-mesh-operator/test/e2e/kind {{.ADDITIONAL_COMMAND_ARGS}}
+        go test -timeout 30m -coverprofile=cover.out github.com/platform-mesh/platform-mesh-operator/test/e2e/kind {{.ADDITIONAL_COMMAND_ARGS}}
 
 
   test:
@@ -82,7 +82,7 @@ tasks:
       - cmd: |
             if [ "$GITHUB_WORKFLOW" = "ci" ]; then
               echo "Running tests in Github Actions"
-              PATH=$(pwd)/{{.LOCAL_BIN}}:$PATH go test -v -timeout 15m -coverprofile=cover.out ./... {{.ADDITIONAL_COMMAND_ARGS}} || {
+              PATH=$(pwd)/{{.LOCAL_BIN}}:$PATH go test -v -timeout 30m -coverprofile=cover.out ./... {{.ADDITIONAL_COMMAND_ARGS}} || {
                 echo "---Listing HelmReleases"
                 kubectl get helmreleases -A
                 echo "---Describing non-ready HelmReleases"
@@ -115,7 +115,7 @@ tasks:
               }
             else
               export PATH=$(pwd)/{{.LOCAL_BIN}}:$PATH
-              go test -timeout 10m -coverprofile=cover.out ./... {{.ADDITIONAL_COMMAND_ARGS}}
+              go test -timeout 30m -coverprofile=cover.out ./... {{.ADDITIONAL_COMMAND_ARGS}}
             fi
         ignore_error: false
 

--- a/api/v1alpha1/platformmesh_types.go
+++ b/api/v1alpha1/platformmesh_types.go
@@ -167,14 +167,14 @@ type KcpWorkspace struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='KcpsetupSubroutine_Ready')].status",name="KCP",type=string,description="KCP status (shows reason if Unknown)",priority=0
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='KcpsetupSubroutine_Ready')].reason",name="KCP_REASON",type=string,description="KCP reason if status is Unknown",priority=1
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='ProvidersecretSubroutine_Ready')].status",name="SECRET",type=string,description="Provider Secret status (shows reason if Unknown)",priority=0
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='ProvidersecretSubroutine_Ready')].reason",name="SECRET_REASON",type=string,description="Provider Secret reason if status is Unknown",priority=1
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='DeploymentSubroutine_Ready')].status",name="DEPLOYMENT",type=string,description="Deployment status (shows reason if Unknown)",priority=0
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='DeploymentSubroutine_Ready')].reason",name="DEPLOYMENT_REASON",type=string,description="Deployment reason if status is Unknown",priority=1
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='WaitSubroutine_Ready')].status",name="WAIT",type=string,description="Wait status (shows reason if Unknown)",priority=0
-// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='WaitSubroutine_Ready')].reason",name="WAIT_REASON",type=string,description="Wait reason if status is Unknown",priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='KcpsetupSubroutine')].status",name="KCP",type=string,description="KCP status (shows reason if Unknown)",priority=0
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='KcpsetupSubroutine')].reason",name="KCP_REASON",type=string,description="KCP reason if status is Unknown",priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='ProvidersecretSubroutine')].status",name="SECRET",type=string,description="Provider Secret status (shows reason if Unknown)",priority=0
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='ProvidersecretSubroutine')].reason",name="SECRET_REASON",type=string,description="Provider Secret reason if status is Unknown",priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='DeploymentSubroutine')].status",name="DEPLOYMENT",type=string,description="Deployment status (shows reason if Unknown)",priority=0
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='DeploymentSubroutine')].reason",name="DEPLOYMENT_REASON",type=string,description="Deployment reason if status is Unknown",priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='WaitSubroutine')].status",name="WAIT",type=string,description="Wait status (shows reason if Unknown)",priority=0
+// +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='WaitSubroutine')].reason",name="WAIT_REASON",type=string,description="Wait reason if status is Unknown",priority=1
 // +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='Ready')].status",name="Ready",type=string,description="Shows if resource is ready",priority=0
 
 // PlatformMesh is the Schema for the platform-mesh API

--- a/config/crd/core.platform-mesh.io_platformmeshes.yaml
+++ b/config/crd/core.platform-mesh.io_platformmeshes.yaml
@@ -16,38 +16,38 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: KCP status (shows reason if Unknown)
-      jsonPath: .status.conditions[?(@.type=='KcpsetupSubroutine_Ready')].status
+      jsonPath: .status.conditions[?(@.type=='KcpsetupSubroutine')].status
       name: KCP
       type: string
     - description: KCP reason if status is Unknown
-      jsonPath: .status.conditions[?(@.type=='KcpsetupSubroutine_Ready')].reason
+      jsonPath: .status.conditions[?(@.type=='KcpsetupSubroutine')].reason
       name: KCP_REASON
       priority: 1
       type: string
     - description: Provider Secret status (shows reason if Unknown)
-      jsonPath: .status.conditions[?(@.type=='ProvidersecretSubroutine_Ready')].status
+      jsonPath: .status.conditions[?(@.type=='ProvidersecretSubroutine')].status
       name: SECRET
       type: string
     - description: Provider Secret reason if status is Unknown
-      jsonPath: .status.conditions[?(@.type=='ProvidersecretSubroutine_Ready')].reason
+      jsonPath: .status.conditions[?(@.type=='ProvidersecretSubroutine')].reason
       name: SECRET_REASON
       priority: 1
       type: string
     - description: Deployment status (shows reason if Unknown)
-      jsonPath: .status.conditions[?(@.type=='DeploymentSubroutine_Ready')].status
+      jsonPath: .status.conditions[?(@.type=='DeploymentSubroutine')].status
       name: DEPLOYMENT
       type: string
     - description: Deployment reason if status is Unknown
-      jsonPath: .status.conditions[?(@.type=='DeploymentSubroutine_Ready')].reason
+      jsonPath: .status.conditions[?(@.type=='DeploymentSubroutine')].reason
       name: DEPLOYMENT_REASON
       priority: 1
       type: string
     - description: Wait status (shows reason if Unknown)
-      jsonPath: .status.conditions[?(@.type=='WaitSubroutine_Ready')].status
+      jsonPath: .status.conditions[?(@.type=='WaitSubroutine')].status
       name: WAIT
       type: string
     - description: Wait reason if status is Unknown
-      jsonPath: .status.conditions[?(@.type=='WaitSubroutine_Ready')].reason
+      jsonPath: .status.conditions[?(@.type=='WaitSubroutine')].reason
       name: WAIT_REASON
       priority: 1
       type: string

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -285,6 +285,7 @@ func (r *ResourceSubroutine) updateOciRepo(ctx context.Context, inst *unstructur
 	url, found, err := unstructured.NestedString(inst.Object, "status", "resource", "access", "imageReference")
 	if err != nil || !found {
 		log.Info().Err(err).Msg("Failed to get imageReference from Resource status")
+		return subroutines.StopWithRequeue(requeueShort, "imageReference status"), nil
 	}
 
 	url = strings.TrimPrefix(url, "oci://")
@@ -339,12 +340,14 @@ func (r *ResourceSubroutine) updateOciRepo(ctx context.Context, inst *unstructur
 func (r *ResourceSubroutine) updateGitRepo(ctx context.Context, inst *unstructured.Unstructured, log *logger.Logger) (subroutines.Result, error) {
 	commit, found, err := unstructured.NestedString(inst.Object, "status", "resource", "access", "commit")
 	if err != nil || !found {
-		log.Info().Err(err).Msg("Failed to get version from Resource status")
+		log.Info().Err(err).Msg("Failed to get commit from Resource status")
+		return subroutines.StopWithRequeue(requeueShort, "commit status"), nil
 	}
 
 	url, found, err := unstructured.NestedString(inst.Object, "status", "resource", "access", "repoUrl")
 	if err != nil || !found {
-		log.Info().Err(err).Msg("Failed to get imageReference from Resource status")
+		log.Info().Err(err).Msg("Failed to get repoUrl from Resource status")
+		return subroutines.StopWithRequeue(requeueShort, "repoUrl status"), nil
 	}
 
 	// Update or create oci repo


### PR DESCRIPTION
## Summary
- Remove `_Ready` suffix from printer column JSONPath filters in PlatformMesh CRD to match the condition types set by `platform-mesh/subroutines` v0.2.6
- Add early return with `StopWithRequeue` in `updateOciRepo` and `updateGitRepo` when Resource status fields are not yet populated, preventing invalid OCI reference errors

## Context
The migration from `golang-commons/controller/lifecycle` to `platform-mesh/subroutines` changed condition type naming from `<Name>_Ready` to `<Name>`. This left all printer columns except `Ready` empty when running `kubectl get platformmeshes`.