### PR TITLE
fix(e2e): switch OCM toolkit source from HelmRepository to OCIRepository

### DIFF
--- a/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
+++ b/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
@@ -1,12 +1,13 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
 metadata:
   name: ocm-k8s-toolkit
   namespace: default
 spec:
-  type: oci
   interval: 5m
-  url: oci://ghcr.io/open-component-model/kubernetes/controller
+  url: oci://ghcr.io/open-component-model/kubernetes/controller/chart
+  ref:
+    tag: "0.3.0"
 ---
 
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -19,13 +20,9 @@ spec:
   interval: 1m
   timeout: 15m
   targetNamespace: ocm-system
-  chart:
-    spec:
-      chart: chart
-      version: "0.3.0"
-      sourceRef:
-        kind: HelmRepository
-        name: ocm-k8s-toolkit
+  chartRef:
+    kind: OCIRepository
+    name: ocm-k8s-toolkit
   values:
     manager:
       concurrency:

--- a/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
+++ b/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
@@ -27,5 +27,3 @@ spec:
     manager:
       concurrency:
         resource: 21
-      logging:
-        level: "4"

--- a/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
+++ b/test/e2e/kind/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: ocm-k8s-toolkit

--- a/test/e2e/kind/yaml/ocm-controller/ocm-controller.yaml
+++ b/test/e2e/kind/yaml/ocm-controller/ocm-controller.yaml
@@ -1,12 +1,13 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
 metadata:
   name: ocm-k8s-toolkit
   namespace: default
 spec:
-  type: oci
   interval: 5m
-  url: oci://ghcr.io/open-component-model/kubernetes/controller
+  url: oci://ghcr.io/open-component-model/kubernetes/controller/chart
+  ref:
+    tag: "0.3.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -18,10 +19,6 @@ spec:
   interval: 1m
   timeout: 15m
   targetNamespace: ocm-system
-  chart:
-    spec:
-      chart: chart
-      version: "0.3.0"
-      sourceRef:
-        kind: HelmRepository
-        name: ocm-k8s-toolkit
+  chartRef:
+    kind: OCIRepository
+    name: ocm-k8s-toolkit

--- a/test/e2e/kind/yaml/ocm-controller/ocm-controller.yaml
+++ b/test/e2e/kind/yaml/ocm-controller/ocm-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: ocm-k8s-toolkit


### PR DESCRIPTION
## Summary

- Switches the e2e test OCM toolkit installation from `HelmRepository` + `chart.spec.sourceRef` back to `OCIRepository` + `chartRef`
- Uses `oci://ghcr.io/open-component-model/kubernetes/controller/chart` with pinned tag `0.3.0`
- Updates both `flux-sync.yaml` (active kustomize base) and `ocm-controller.yaml` (reference copy)