### PR TITLE
feat: Enable scoped kubeconfig

### DIFF
--- a/pkg/subroutines/defaults.go
+++ b/pkg/subroutines/defaults.go
@@ -29,9 +29,10 @@ var DefaultProviderConnections = []corev1alpha1.ProviderConnection{
 		AdminAuth: ptr.To(true),
 	},
 	{
-		Path:      "root:platform-mesh-system",
-		Secret:    "rebac-authz-webhook-kubeconfig",
-		AdminAuth: ptr.To(true),
+		Path:          "root:platform-mesh-system",
+		Secret:        "rebac-authz-webhook-kubeconfig",
+		APIExportName: ptr.To("core.platform-mesh.io"),
+		AdminAuth:     ptr.To(false),
 	},
 	{
 		Path:      "root:platform-mesh-system",
@@ -49,14 +50,16 @@ var DefaultProviderConnections = []corev1alpha1.ProviderConnection{
 		AdminAuth: ptr.To(true),
 	},
 	{
-		Path:      "root:platform-mesh-system",
-		Secret:    "extension-manager-operator-kubeconfig",
-		AdminAuth: ptr.To(true),
+		Path:          "root:platform-mesh-system",
+		Secret:        "extension-manager-operator-kubeconfig",
+		APIExportName: ptr.To("core.platform-mesh.io"),
+		AdminAuth:     ptr.To(false),
 	},
 	{
-		Path:      "root:platform-mesh-system",
-		Secret:    "iam-service-kubeconfig",
-		AdminAuth: ptr.To(true),
+		Path:          "root:platform-mesh-system",
+		Secret:        "iam-service-kubeconfig",
+		APIExportName: ptr.To("core.platform-mesh.io"),
+		AdminAuth:     ptr.To(false),
 	},
 	{
 		Path:      "root:orgs",
@@ -132,9 +135,9 @@ var DEFAULT_WAIT_CONFIG = corev1alpha1.WaitConfig{
 	ResourceTypes: []corev1alpha1.ResourceType{
 		{
 			GroupVersionKind: v1.GroupVersionKind{
-				Group: "helm.toolkit.fluxcd.io",
+				Group:   "helm.toolkit.fluxcd.io",
 				Version: "v2",
-				Kind:  "HelmRelease",
+				Kind:    "HelmRelease",
 			},
 			Namespace: "default",
 			LabelSelector: v1.LabelSelector{
@@ -151,9 +154,9 @@ var DEFAULT_WAIT_CONFIG = corev1alpha1.WaitConfig{
 		},
 		{
 			GroupVersionKind: v1.GroupVersionKind{
-				Group: "helm.toolkit.fluxcd.io",
+				Group:   "helm.toolkit.fluxcd.io",
 				Version: "v2",
-				Kind:  "HelmRelease",
+				Kind:    "HelmRelease",
 			},
 			Namespace: "default",
 			LabelSelector: v1.LabelSelector{

--- a/pkg/subroutines/providersecret_test.go
+++ b/pkg/subroutines/providersecret_test.go
@@ -1637,7 +1637,14 @@ func (s *ProvidersecretTestSuite) TestClusterNotFoundInKubeconfig() {
 func (s *ProvidersecretTestSuite) TestHandleProviderConnections() {
 	// Setup test instance
 	instance := s.getBaseInstance()
-	instance.Spec.Kcp.ProviderConnections = nil
+	// Exercise admin kubeconfig wiring only: defaults may use scoped kubeconfig for some secrets.
+	adminDefaults := make([]corev1alpha1.ProviderConnection, len(DefaultProviderConnections))
+	for i, pc := range DefaultProviderConnections {
+		pc := pc
+		pc.AdminAuth = ptr.To(true)
+		adminDefaults[i] = pc
+	}
+	instance.Spec.Kcp.ProviderConnections = adminDefaults
 	instance.Spec.Kcp.ExtraProviderConnections = []corev1alpha1.ProviderConnection{
 		{
 			AdminAuth:         ptr.To(true),


### PR DESCRIPTION
Enable scoped kubeconfig generation by default for:
- rebac-authz-webhook
- extension-manager-operator
- iam-service
Those operators alrady work with scoped kubeconfig

Is part of solution for https://github.com/platform-mesh/platform-mesh-operator/issues/79