### PR TITLE
docs: add remote deployment, configuration flow, and templating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ spec:
     namespace: platform-mesh-system
 ```
 
+The PlatformMesh resource and its profile ConfigMap are linked by naming convention: a PlatformMesh instance named `foo` in namespace `bar` expects a ConfigMap named `foo-profile` in the same namespace. Alternatively, use `spec.profileConfigMap` to point to a specific ConfigMap by name and namespace. Both resources must live on the same cluster (the runtime cluster in remote deployments).
+
 The ConfigMap must contain a `profile.yaml` key with two top-level sections: `infra` and `components`. The operator renders Go templates inside the profile at reconcile time, substituting variables like `{{ .baseDomainPort }}` and `{{ .baseDomain }}` from the exposure configuration.
 
 ### Exposure Configuration
@@ -183,6 +185,103 @@ spec:
 
 If `spec.wait` is not specified, the subroutine uses default configurations that wait for the `platform-mesh-operator-infra-components` HelmRelease to be ready.
 
+## Configuration Flow
+
+This section describes how operator-level configuration, the PlatformMesh CR, and the profile ConfigMap combine to produce downstream Kubernetes resources.
+
+### Operator Configuration
+
+The operator binary accepts the following CLI flags (defined in `internal/config/config.go`):
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--workspace-dir` | `/operator/` | Root directory for templates and manifests |
+| `--kcp-url` | _(none)_ | KCP cluster URL |
+| `--kcp-namespace` | `platform-mesh-system` | KCP namespace |
+| `--kcp-root-shard-name` | `root` | KCP root shard name |
+| `--kcp-front-proxy-name` | `frontproxy` | KCP front-proxy name |
+| `--kcp-front-proxy-port` | `8443` | KCP front-proxy port |
+| `--kcp-cluster-admin-secret-name` | `kcp-cluster-admin-client-cert` | Cluster-admin secret name |
+| `--idp-registration-allowed` | `false` | Allow IDP registration |
+| `--subroutines-deployment-enabled` | `true` | Enable deployment subroutine |
+| `--subroutines-deployment-enable-istio` | `true` | Enable Istio integration |
+| `--authorization-webhook-secret-name` | `kcp-webhook-secret` | Authorization webhook secret name |
+| `--authorization-webhook-secret-ca-name` | `rebac-authz-webhook-cert` | Authorization webhook CA secret name |
+| `--subroutines-kcp-setup-enabled` | `true` | Enable KCP setup subroutine |
+| `--domain-certificate-ca-secret-name` | `domain-certificate` | Domain certificate CA secret name |
+| `--domain-certificate-ca-secret-key` | `ca.crt` | Domain certificate CA secret key |
+| `--subroutines-provider-secret-enabled` | `true` | Enable provider secret subroutine |
+| `--subroutines-feature-toggles-enabled` | `false` | Enable feature toggles subroutine |
+| `--subroutines-wait-enabled` | `true` | Enable wait subroutine |
+| `--remote-runtime-kubeconfig` | _(none)_ | Kubeconfig for remote runtime cluster |
+| `--remote-runtime-infra-secret-name` | _(none)_ | Secret name for FluxCD to reach runtime |
+| `--remote-runtime-infra-secret-key` | _(none)_ | Secret key for FluxCD to reach runtime |
+| `--remote-infra-kubeconfig` | _(none)_ | Kubeconfig for remote infra cluster |
+
+### PlatformMesh CR → Profile → Downstream Resources
+
+The configuration flows through three layers:
+
+```
+Profile ConfigMap (profile.yaml: components.services.<name>.values)   ← broad/general config
+        │
+        ▼  deep-merge (spec.Values overrides profile)
+PlatformMesh CR (spec.values.services.<name>.values)                  ← per-instance overrides
+        │
+        ▼  Go template rendering + variable substitution
+Go Templates (gotemplates/) → HelmRelease spec.values / ArgoCD Application helm.values
+```
+
+**Profile ConfigMap** (`profile.yaml`) provides the **broad, general configuration** for all services. It defines the full deployment blueprint — which services are enabled, their Helm chart values, dependencies, and deployment settings. The `components.services.<name>.values` map becomes the base Helm values for each service.
+
+**PlatformMesh CR** (`spec.values`) provides **per-instance customization and overrides**. Values here are deep-merged on top of the profile, allowing environment-specific tuning without duplicating the entire profile.
+
+After merging, the combined values are processed through Go template rendering (resolving expressions like `{{ .baseDomain }}`) and then passed **1-to-1** to each service's downstream deployment resource:
+- For **FluxCD**: the merged `services.<name>.values` map is set directly as the HelmRelease's `spec.values`
+- For **ArgoCD**: the merged values are rendered into the Application's `spec.source.helm.values`
+
+The profile has two top-level sections:
+
+- `infra` — defines infrastructure components (cert-manager, traefik, etcd-druid, gateway-api) with their enabled state, intervals, namespaces, values
+- `components` — defines application services with enabled state, chart source, Helm values, dependsOn, syncWave, imageResources
+
+### Merge Hierarchy
+
+Template variables are built with the following precedence (highest wins):
+
+| Layer | Source | Applies to |
+|-------|--------|-----------|
+| 1 (highest) | `PlatformMesh.spec.Values` / `spec.infraValues` | Components / Infra templates |
+| 2 | Operator flags (kubeConfig, remoteRuntime) | All templates |
+| 3 | TemplateVars (derived from `spec.exposure`) | All templates |
+| 4 (lowest) | Profile ConfigMap sections | All templates |
+
+For **infra templates** (`gotemplates/infra/infra`):
+```
+profile.infra (base) → TemplateVars → remote config (kubeConfigEnabled, etc.)
+```
+
+For **runtime templates** (`gotemplates/infra/runtime`):
+```
+profile.infra (base) → TemplateVars → spec.Values → spec.OCM → profile.components.services
+```
+
+For **component templates** (`gotemplates/components/infra` and `gotemplates/components/runtime`):
+```
+profile.components (base) → TemplateVars → spec.Values.services (deep-merged per service)
+```
+
+### How Configuration Reflects on Downstream Resources
+
+| Downstream Resource | Created by | Key configuration sources |
+|--------------------|-----------|--------------------------|
+| **HelmRelease** | `gotemplates/infra/infra/*.yaml` or `gotemplates/components/infra/helmreleases.yaml` | Profile service config (chart, values, targetNamespace, dependsOn, suspend), remote kubeConfig |
+| **OCIRepository** | ResourceSubroutine (from OCM Resource status) | OCM image reference and version from Resource `.status.resource.access.imageReference` |
+| **HelmRepository** | ResourceSubroutine (from OCM Resource status) | Helm repo URL from Resource `.status.resource.access.helmRepository` |
+| **GitRepository** | ResourceSubroutine (from OCM Resource status) | Git URL and ref from Resource `.status.resource.access.repoUrl` |
+| **ArgoCD Application** | `gotemplates/infra/infra/*.yaml` or `gotemplates/components/infra/applications.yaml` | Profile service config (values, syncWave, ignoreDifferences), destinationServer, repoURL/targetRevision from ResourceSubroutine |
+| **OCM Resource** | `gotemplates/infra/runtime/*.yaml` or `gotemplates/components/runtime/*.yaml` | OCM repo name, component name, referencePath from profile + spec.OCM |
+
 ## Architecture
 
 The operator uses a subroutine-based architecture (`github.com/platform-mesh/subroutines`) with a lifecycle manager that executes subroutines **sequentially in a fixed order**. If any subroutine returns an error or explicitly stops the chain, the remaining subroutines are skipped and the reconcile loop is retried after a requeue interval.
@@ -215,6 +314,246 @@ These templates are rendered using the profile ConfigMap data merged with exposu
 The operator supports two deployment technologies (configured per-section in the profile):
 - **FluxCD** (`fluxcd`): Creates HelmRelease and OCM Resource objects. FluxCD reconciles them into the cluster.
 - **ArgoCD** (`argocd`): Creates ArgoCD Application objects. The ResourceSubroutine manages OCI repository references for ArgoCD.
+
+### Templating
+
+The operator uses Go's `text/template` package to render Kubernetes manifests from YAML template files. Templates are located under `gotemplates/` (relative to `--workspace-dir`).
+
+#### Template Directory Structure
+
+```
+gotemplates/
+├── infra/
+│   ├── infra/           → Infrastructure HelmReleases / ArgoCD Applications (applied to infra cluster)
+│   │   ├── cert-manager/helmrelease.yaml, application.yaml
+│   │   ├── traefik/helmrelease.yaml, helmrelease-crds.yaml, application.yaml, application-crds.yaml
+│   │   ├── etcd-druid/application.yaml
+│   │   ├── gateway-api/kustomization.yaml, application.yaml
+│   │   └── appproject.yaml
+│   └── runtime/         → OCM Resources + infra HelmReleases (routed per-GVK)
+│       ├── cert-manager/resource.yaml, resource-*.yaml
+│       ├── traefik/resource.yaml, resource-crds.yaml
+│       ├── etcd-druid/resource.yaml, resource-image.yaml, helmrelease.yaml
+│       └── gateway-api/resource.yaml
+└── components/
+    ├── infra/           → Service HelmReleases / ArgoCD Applications (applied to infra cluster)
+    │   ├── helmreleases.yaml
+    │   └── applications.yaml
+    └── runtime/         → Service OCM Resources (applied to runtime cluster)
+        ├── ocm-chart-resources.yaml
+        └── ocm-image-resources.yaml
+```
+
+#### Template Rendering Flow
+
+1. **Walk directory** — recursively traverse all `.yaml` files in the target directory
+2. **Filter by deployment technology** — skip files based on the active technology:
+   - ArgoCD: skips `helmrelease*.yaml` and `kustomization*.yaml`
+   - FluxCD: skips `application*.yaml`
+3. **Parse template** — parse the file as a Go template with the custom function map
+4. **Execute template** — render with the merged template variables
+5. **Split multi-document YAML** — split on `---` separators
+6. **Post-process** — optionally preserve existing fields (e.g., ArgoCD source fields managed by ResourceSubroutine)
+7. **Apply via Server-Side Apply** — apply each object to the target cluster with field manager `platform-mesh-deployment`
+
+#### Template-to-Cluster Routing
+
+| Template Directory | Target Cluster | Routing Logic |
+|-------------------|---------------|---------------|
+| `gotemplates/infra/infra/` | Infra | Applied directly to `clientInfra` |
+| `gotemplates/infra/runtime/` | Mixed | OCM Resources (`delivery.ocm.software/v1alpha1`) → `clientRuntime`; everything else → `clientInfra` |
+| `gotemplates/components/infra/` | Infra | Applied directly to `clientInfra` |
+| `gotemplates/components/runtime/` | Runtime | Applied directly to `clientRuntime` |
+
+#### Available Template Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `default` | `default <default> <value>` | Returns `default` if `value` is zero/empty |
+| `toYaml` | `toYaml <value>` | Marshals value to a YAML string |
+| `nindent` | `nindent <spaces> <string>` | Indents a multi-line string by N spaces with a leading newline |
+| `or` | `or <a> <b>` | Returns `a` if non-zero, otherwise `b` |
+| `and` | `and <a> <b>` | Returns true if both are non-zero |
+| `not` | `not <value>` | Returns true if value is zero/empty |
+
+#### Template Variables
+
+**Infra templates** (`gotemplates/infra/infra/`) receive the profile's `infra` section merged with:
+
+| Variable | Source |
+|----------|--------|
+| `releaseNamespace` | PlatformMesh instance namespace |
+| `helmReleaseNamespace` | Same as releaseNamespace |
+| `deploymentTechnology` | Profile or templateVars (`fluxcd` / `argocd`) |
+| `kubeConfigEnabled` | `true` if `--remote-runtime-kubeconfig` is set |
+| `kubeConfigSecretName` | `--remote-runtime-infra-secret-name` |
+| `kubeConfigSecretKey` | `--remote-runtime-infra-secret-key` |
+| `<component>.enabled` | From profile infra section (e.g., `.certManager.enabled`) |
+| `<component>.values` | Helm values from profile |
+
+**Component templates** (`gotemplates/components/`) receive:
+
+| Variable | Source |
+|----------|--------|
+| `values` | Merged profile.components + spec.Values (contains `services` map) |
+| `values.services.<name>.enabled` | Per-service enabled flag |
+| `values.services.<name>.values` | Per-service Helm values |
+| `releaseNamespace` | PlatformMesh instance namespace |
+| `kubeConfigEnabled` | Remote runtime flag |
+| `kubeConfigSecretName` / `kubeConfigSecretKey` | Remote runtime secret ref |
+| `deploymentTechnology` | `fluxcd` or `argocd` |
+| `destinationServer` | ArgoCD destination (from profile's `components.destinationServer`) |
+| `baseDomain` | From `spec.exposure.baseDomain` |
+| `port` | From `spec.exposure.port` |
+| `baseDomainWithPort` | Combined domain:port (port omitted if 443) |
+
+**Runtime templates** (`gotemplates/infra/runtime/` and `gotemplates/components/runtime/`) additionally receive:
+
+| Variable | Source |
+|----------|--------|
+| `ocm.repo.name` | OCM repository name |
+| `ocm.component.name` | OCM component name |
+| `ocm.referencePath` | Reference path list |
+| `services` | Merged services from profile.components |
+
+#### Profile as Template
+
+The profile ConfigMap itself is rendered as a Go template before being parsed as YAML. This allows profile values to reference exposure-derived variables:
+
+```yaml
+# Inside profile.yaml
+components:
+  services:
+    my-service:
+      enabled: true
+      values:
+        ingress:
+          host: "my-service.{{ .baseDomain }}"
+          port: {{ .port }}
+```
+
+Available variables in the profile template context: `baseDomain`, `baseDomainPort`, `port`, `protocol`, `helmReleaseNamespace`.
+
+#### Template Syntax Examples
+
+**Conditional rendering:**
+```yaml
+{{- if .certManager.enabled }}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ .certManager.name }}
+{{- end }}
+```
+
+**Remote deployment kubeConfig injection:**
+```yaml
+{{- if $.kubeConfigEnabled }}
+  kubeConfig:
+    secretRef:
+      name: {{ $.kubeConfigSecretName }}
+      key: {{ $.kubeConfigSecretKey }}
+{{- end }}
+```
+
+**Iterating over services (multi-document):**
+```yaml
+{{- range $service, $config := .values.services }}
+{{- if $config.enabled -}}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ $service }}
+spec:
+  values:
+{{ toYaml $config.values | nindent 4 }}
+---
+{{ end -}}
+{{ end -}}
+```
+
+## Remote Deployment
+
+The operator supports multi-cluster deployment where the operator process runs in a **local** cluster but manages resources on separate **runtime** and **infra** clusters.
+
+### Cluster Roles
+
+| Cluster | What lives there | Client used |
+|---------|-----------------|-------------|
+| **Local** | Operator pod, leader election | In-cluster config |
+| **Runtime** | KCP (RootShard, FrontProxy), OCM Resources, PlatformMesh CR, profile ConfigMap | `clientRuntime` |
+| **Infra** | FluxCD (HelmReleases, OCIRepositories, HelmRepositories) or ArgoCD (Applications, AppProjects) | `clientInfra` |
+
+Remote deployment is considered when **Runtime** and **Infra** are different clusters. In a single-cluster deployment all three roles collapse into one cluster (`clientRuntime == clientInfra`).
+
+When using remote deployment, the **PlatformMesh resource** and the **profile ConfigMap** must be created on the runtime cluster — the operator reconciles them remotely via `--remote-runtime-kubeconfig`.
+
+### Enabling Remote Deployment
+
+Remote deployment is activated by providing a kubeconfig path to the operator:
+
+```
+--remote-runtime-kubeconfig /path/to/runtime-kubeconfig
+--remote-runtime-infra-secret-name <secret-name>
+--remote-runtime-infra-secret-key <secret-key>
+--remote-infra-kubeconfig /path/to/infra-kubeconfig
+```
+
+The check is simply whether a kubeconfig is set:
+
+```go
+func (r *RemoteClusterConfig) IsEnabled() bool {
+    return r.Kubeconfig != ""
+}
+```
+
+- `--remote-runtime-kubeconfig` — tells the operator to watch and reconcile PlatformMesh resources on a remote runtime cluster (KCP workspace). The manager's REST config points to this cluster. The PlatformMesh CR and profile ConfigMap live on this remote cluster.
+- `--remote-infra-kubeconfig` — only needed when the operator does not run on the infra cluster (i.e., **Local** != **Infra**). Makes the operator create FluxCD/ArgoCD resources on a separate infra cluster instead of the local cluster.
+
+### How Remote Differs from Local
+
+| Aspect | Local (single-cluster) | Remote (multi-cluster) |
+|--------|----------------------|----------------------|
+| Manager REST config | In-cluster | `--remote-runtime-kubeconfig` |
+| Infra client | Same as runtime | Separate `--remote-infra-kubeconfig` or in-cluster |
+| HelmRelease spec | No `kubeConfig` field | Includes `spec.kubeConfig.secretRef` |
+| ArgoCD Application | `destination.server: https://kubernetes.default.svc` | `destination.server` set to remote cluster endpoint via `destinationServer` profile field |
+| OCM Resources | Applied locally | Applied to runtime cluster |
+| FluxCD sources | Applied locally | Applied to infra cluster |
+
+### Effect on Downstream Resources
+
+When `--remote-runtime-kubeconfig` is provided, the following template variables are injected:
+
+```yaml
+kubeConfigEnabled: true
+kubeConfigSecretName: <--remote-runtime-infra-secret-name>
+kubeConfigSecretKey: <--remote-runtime-infra-secret-key>
+```
+
+**FluxCD HelmReleases** gain a `kubeConfig` block telling FluxCD to deploy to the remote runtime cluster:
+
+```yaml
+spec:
+  kubeConfig:
+    secretRef:
+      name: <secret-name>
+      key: <secret-key>
+```
+
+**ArgoCD Applications** use the `destinationServer` field from the profile to point to the remote cluster:
+
+```yaml
+spec:
+  destination:
+    server: https://remote-cluster-api:6443  # from profile's destinationServer
+```
+
+**OCM Resources** are always applied to the runtime cluster (where the OCM controller runs), regardless of remote mode.
+
+### Known Issues and Limitations
+
+- The operator currently supports only a **single remote deployment** — one runtime cluster and one infra cluster per operator instance. To manage multiple remote environments, deploy separate operator instances.
 
 ## Subroutines
 

--- a/README.md
+++ b/README.md
@@ -476,6 +476,34 @@ spec:
 
 The operator supports multi-cluster deployment where the operator process runs in a **local** cluster but manages resources on separate **runtime** and **infra** clusters.
 
+```mermaid
+graph LR
+    subgraph Local["Local cluster"]
+        OP["platform-mesh-operator"]
+    end
+
+    subgraph Runtime["Runtime cluster"]
+        PM["PlatformMesh CR"]
+        PROF["Profile ConfigMap"]
+        KCP["kcp (RootShard, FrontProxy)"]
+        OCM["OCM Resources"]
+    end
+
+    subgraph Infra["Infra cluster"]
+        FLUX["FluxCD / ArgoCD"]
+        HR["HelmReleases"]
+        OCI["OCIRepositories"]
+        APPS["ArgoCD Applications"]
+    end
+
+    OP -->|"reconciles (remote-runtime-kubeconfig)"| PM
+    OP -->|"reads"| PROF
+    OP -->|"creates OCM Resources"| OCM
+    OP -->|"creates HelmReleases / Apps"| HR
+    OP -->|"creates HelmReleases / Apps"| APPS
+    FLUX -->|"deploys workloads via kubeConfig secret"| Runtime
+```
+
 ### Cluster Roles
 
 | Cluster | What lives there | Client used |


### PR DESCRIPTION
**Title:** docs: add remote deployment, configuration flow, and templating documentation

**Body:**

## Summary

- Add comprehensive documentation for the remote deployment feature: cluster roles, how to enable it, how it differs from local, effect on downstream resources, and known limitations
- Add a Configuration Flow section documenting operator CLI flags, PlatformMesh CR → Profile → downstream resources flow, and the merge hierarchy
- Add a Templating section covering the Go template engine, directory structure, rendering pipeline, template-to-cluster routing, available functions/variables, and syntax examples
- Clarify how profile ConfigMap and PlatformMesh CR are linked (naming convention or explicit `spec.profileConfigMap`) and that both live on the runtime cluster in remote deployments
- Document that profile provides broad/general config, `spec.values` provides per-instance overrides, and merged values are passed 1-to-1 to each service's HelmRelease or ArgoCD Application

## Test plan

- [ ] Review rendered markdown for formatting correctness
- [ ] Cross-reference flag names with `internal/config/config.go`
- [ ] Cross-reference template directory structure with `gotemplates/`
- [ ] Verify merge hierarchy description against `deployment.go` logic

---

Note: the `platform-mesh.github.io` docs site file was also updated locally at `/home/akafazov/src/github.com/platform-mesh/platform-mesh.github.io/reference/components/platform-mesh-operator.md` — that change will need a separate PR in that repository.

refers to https://github.com/platform-mesh/helm-charts/issues/1607