### PR TITLE
Add custom Prometheus metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/platform-mesh/golang-commons v0.17.1
 	github.com/platform-mesh/subroutines v0.4.3
+	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -88,6 +89,7 @@ require (
 	github.com/kcp-dev/apimachinery/v2 v2.31.1 // indirect
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -98,7 +100,6 @@ require (
 	github.com/onsi/gomega v1.39.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/internal/controller/platformmesh_controller.go
+++ b/internal/controller/platformmesh_controller.go
@@ -62,14 +62,12 @@ type PlatformMeshReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 func (r *PlatformMeshReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	start := time.Now()
 	result, err := r.lifecycle.Reconcile(ctx, req)
 	labelResult := "success"
 	if err != nil {
 		labelResult = "error"
 	}
 	metrics.ReconcileTotal.WithLabelValues(pmReconcilerName, labelResult).Inc()
-	metrics.ReconcileDuration.WithLabelValues(pmReconcilerName).Observe(time.Since(start).Seconds())
 	return result, err
 }
 

--- a/internal/controller/platformmesh_controller.go
+++ b/internal/controller/platformmesh_controller.go
@@ -41,6 +41,7 @@ import (
 
 	corev1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 	pmsubs "github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 )
 
@@ -61,7 +62,15 @@ type PlatformMeshReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 func (r *PlatformMeshReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues(pmReconcilerName, labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues(pmReconcilerName).Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/resource_controller.go
+++ b/internal/controller/resource_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	pmconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
@@ -60,14 +59,12 @@ type ResourceReconciler struct {
 }
 
 func (r *ResourceReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	start := time.Now()
 	result, err := r.lifecycle.Reconcile(ctx, req)
 	labelResult := "success"
 	if err != nil {
 		labelResult = "error"
 	}
 	metrics.ReconcileTotal.WithLabelValues(resourceReconcilerName, labelResult).Inc()
-	metrics.ReconcileDuration.WithLabelValues(resourceReconcilerName).Observe(time.Since(start).Seconds())
 	return result, err
 }
 

--- a/internal/controller/resource_controller.go
+++ b/internal/controller/resource_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	pmconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
@@ -37,6 +38,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 	pmsubs "github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines/resource"
 )
@@ -58,7 +60,15 @@ type ResourceReconciler struct {
 }
 
 func (r *ResourceReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues(resourceReconcilerName, labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues(resourceReconcilerName).Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,16 +15,6 @@ var (
 		[]string{"controller", "result"},
 	)
 
-	// ReconcileDuration observes how long each reconcile loop takes, labelled by controller.
-	ReconcileDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "platform_mesh_operator_reconcile_duration_seconds",
-			Help:    "Duration of reconcile calls in seconds by controller.",
-			Buckets: prometheus.DefBuckets,
-		},
-		[]string{"controller"},
-	)
-
 	// SubroutineTotal counts Process calls per subroutine and result (success/error).
 	SubroutineTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -48,7 +38,6 @@ var (
 func init() {
 	ctrlmetrics.Registry.MustRegister(
 		ReconcileTotal,
-		ReconcileDuration,
 		SubroutineTotal,
 		SubroutineDuration,
 	)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// ReconcileTotal counts reconcile calls per controller and result (success/error).
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "platform_mesh_operator_reconcile_total",
+			Help: "Total number of reconcile calls by controller and result.",
+		},
+		[]string{"controller", "result"},
+	)
+
+	// ReconcileDuration observes how long each reconcile loop takes, labelled by controller.
+	ReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "platform_mesh_operator_reconcile_duration_seconds",
+			Help:    "Duration of reconcile calls in seconds by controller.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"controller"},
+	)
+
+	// SubroutineTotal counts Process calls per subroutine and result (success/error).
+	SubroutineTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "platform_mesh_operator_subroutine_total",
+			Help: "Total number of subroutine Process calls by subroutine and result.",
+		},
+		[]string{"subroutine", "result"},
+	)
+
+	// SubroutineDuration observes how long each subroutine Process call takes.
+	SubroutineDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "platform_mesh_operator_subroutine_duration_seconds",
+			Help:    "Duration of subroutine Process calls in seconds by subroutine.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"subroutine"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		ReconcileTotal,
+		ReconcileDuration,
+		SubroutineTotal,
+		SubroutineDuration,
+	)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -29,14 +29,6 @@ func (s *MetricsTestSuite) TestReconcileTotal() {
 	s.Require().Equal(before+1, testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("ResourceReconciler", "error")))
 }
 
-// TestReconcileDuration verifies that the ReconcileDuration histogram records
-// observations per controller label.
-func (s *MetricsTestSuite) TestReconcileDuration() {
-	before := testutil.CollectAndCount(metrics.ReconcileDuration)
-	metrics.ReconcileDuration.WithLabelValues("PlatformMeshReconciler").Observe(0.05)
-	s.Assert().Greater(testutil.CollectAndCount(metrics.ReconcileDuration), before)
-}
-
 // TestSubroutineTotal verifies that the SubroutineTotal counter increments
 // correctly for each subroutine/result label combination.
 func (s *MetricsTestSuite) TestSubroutineTotal() {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,58 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
+)
+
+type MetricsTestSuite struct {
+	suite.Suite
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}
+
+// TestReconcileTotal verifies that the ReconcileTotal counter increments
+// correctly for each controller/result label combination.
+func (s *MetricsTestSuite) TestReconcileTotal() {
+	before := testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("PlatformMeshReconciler", "success"))
+	metrics.ReconcileTotal.WithLabelValues("PlatformMeshReconciler", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("PlatformMeshReconciler", "success")))
+
+	before = testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("ResourceReconciler", "error"))
+	metrics.ReconcileTotal.WithLabelValues("ResourceReconciler", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("ResourceReconciler", "error")))
+}
+
+// TestReconcileDuration verifies that the ReconcileDuration histogram records
+// observations per controller label.
+func (s *MetricsTestSuite) TestReconcileDuration() {
+	before := testutil.CollectAndCount(metrics.ReconcileDuration)
+	metrics.ReconcileDuration.WithLabelValues("PlatformMeshReconciler").Observe(0.05)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.ReconcileDuration), before)
+}
+
+// TestSubroutineTotal verifies that the SubroutineTotal counter increments
+// correctly for each subroutine/result label combination.
+func (s *MetricsTestSuite) TestSubroutineTotal() {
+	before := testutil.ToFloat64(metrics.SubroutineTotal.WithLabelValues("deployment", "success"))
+	metrics.SubroutineTotal.WithLabelValues("deployment", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.SubroutineTotal.WithLabelValues("deployment", "success")))
+
+	before = testutil.ToFloat64(metrics.SubroutineTotal.WithLabelValues("kcpsetup", "error"))
+	metrics.SubroutineTotal.WithLabelValues("kcpsetup", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.SubroutineTotal.WithLabelValues("kcpsetup", "error")))
+}
+
+// TestSubroutineDuration verifies that the SubroutineDuration histogram records
+// observations per subroutine label.
+func (s *MetricsTestSuite) TestSubroutineDuration() {
+	before := testutil.CollectAndCount(metrics.SubroutineDuration)
+	metrics.SubroutineDuration.WithLabelValues("deployment").Observe(0.1)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.SubroutineDuration), before)
+}

--- a/pkg/subroutines/deployment.go
+++ b/pkg/subroutines/deployment.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	pmconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/errors"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/merge"
 )
 
@@ -167,7 +169,16 @@ func (r *DeploymentSubroutine) Finalizers(instance client.Object) []string { // 
 	return []string{}
 }
 
-func (r *DeploymentSubroutine) Process(ctx context.Context, runtimeObj client.Object) (subroutines.Result, error) {
+func (r *DeploymentSubroutine) Process(ctx context.Context, runtimeObj client.Object) (res subroutines.Result, err error) {
+	start := time.Now()
+	defer func() {
+		labelResult := "success"
+		if err != nil {
+			labelResult = "error"
+		}
+		metrics.SubroutineTotal.WithLabelValues(r.GetName(), labelResult).Inc()
+		metrics.SubroutineDuration.WithLabelValues(r.GetName()).Observe(time.Since(start).Seconds())
+	}()
 	inst := runtimeObj.(*v1alpha1.PlatformMesh)
 	log := logger.LoadLoggerFromContext(ctx).ChildLogger("subroutine", r.GetName())
 	operatorCfg := pmconfig.LoadConfigFromContext(ctx).(config.OperatorConfig)

--- a/pkg/subroutines/featuretoggles.go
+++ b/pkg/subroutines/featuretoggles.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	pmconfig "github.com/platform-mesh/golang-commons/config"
 	gcerrors "github.com/platform-mesh/golang-commons/errors"
@@ -18,6 +19,7 @@ import (
 
 	corev1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 )
 
 const FeatureToggleSubroutineName = "FeatureToggleSubroutine"
@@ -62,7 +64,16 @@ func (r *FeatureToggleSubroutine) Finalizers(instance client.Object) []string { 
 	return []string{}
 }
 
-func (r *FeatureToggleSubroutine) Process(ctx context.Context, runtimeObj client.Object) (subroutines.Result, error) {
+func (r *FeatureToggleSubroutine) Process(ctx context.Context, runtimeObj client.Object) (res subroutines.Result, err error) {
+	start := time.Now()
+	defer func() {
+		labelResult := "success"
+		if err != nil {
+			labelResult = "error"
+		}
+		metrics.SubroutineTotal.WithLabelValues(r.GetName(), labelResult).Inc()
+		metrics.SubroutineDuration.WithLabelValues(r.GetName()).Observe(time.Since(start).Seconds())
+	}()
 	log := logger.LoadLoggerFromContext(ctx).ChildLogger("subroutine", r.GetName())
 	operatorCfg := pmconfig.LoadConfigFromContext(ctx).(config.OperatorConfig)
 

--- a/pkg/subroutines/kcpsetup.go
+++ b/pkg/subroutines/kcpsetup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
 
 	pmconfig "github.com/platform-mesh/golang-commons/config"
 	gcerrors "github.com/platform-mesh/golang-commons/errors"
@@ -19,6 +20,7 @@ import (
 
 	corev1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 
 	kcpapiv1alpha "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	kcptenancyv1alpha "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
@@ -68,7 +70,16 @@ func (r *KcpsetupSubroutine) Finalizers(_ client.Object) []string { // coverage-
 	return []string{KcpsetupSubroutineFinalizer}
 }
 
-func (r *KcpsetupSubroutine) Process(ctx context.Context, runtimeObj client.Object) (subroutines.Result, error) {
+func (r *KcpsetupSubroutine) Process(ctx context.Context, runtimeObj client.Object) (res subroutines.Result, err error) {
+	start := time.Now()
+	defer func() {
+		labelResult := "success"
+		if err != nil {
+			labelResult = "error"
+		}
+		metrics.SubroutineTotal.WithLabelValues(r.GetName(), labelResult).Inc()
+		metrics.SubroutineDuration.WithLabelValues(r.GetName()).Observe(time.Since(start).Seconds())
+	}()
 	log := logger.LoadLoggerFromContext(ctx).ChildLogger("subroutine", r.GetName())
 	operatorCfg := pmconfig.LoadConfigFromContext(ctx).(config.OperatorConfig)
 
@@ -78,7 +89,7 @@ func (r *KcpsetupSubroutine) Process(ctx context.Context, runtimeObj client.Obje
 	rootShard := &unstructured.Unstructured{}
 	rootShard.SetGroupVersionKind(schema.GroupVersionKind{Group: "operator.kcp.io", Version: "v1alpha1", Kind: "RootShard"})
 	// Wait for root shard to be ready
-	err := r.client.Get(ctx, types.NamespacedName{Name: operatorCfg.KCP.RootShardName, Namespace: operatorCfg.KCP.Namespace}, rootShard)
+	err = r.client.Get(ctx, types.NamespacedName{Name: operatorCfg.KCP.RootShardName, Namespace: operatorCfg.KCP.Namespace}, rootShard)
 	if err != nil || !matchesConditionWithStatus(rootShard, "Available", "True") {
 		log.Info().Msg("RootShard is not ready..")
 		return subroutines.StopWithRequeue(DefaultRequeueInterval, "RootShard is not ready"), nil

--- a/pkg/subroutines/providersecret.go
+++ b/pkg/subroutines/providersecret.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"time"
 
 	pmconfig "github.com/platform-mesh/golang-commons/config"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,7 @@ import (
 
 	corev1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 )
 
 // HelmGetter is an interface for getting Helm releases
@@ -79,7 +81,16 @@ func (r *ProvidersecretSubroutine) Finalize(
 
 func (r *ProvidersecretSubroutine) Process(
 	ctx context.Context, runtimeObj client.Object,
-) (subroutines.Result, error) {
+) (res subroutines.Result, err error) {
+	start := time.Now()
+	defer func() {
+		labelResult := "success"
+		if err != nil {
+			labelResult = "error"
+		}
+		metrics.SubroutineTotal.WithLabelValues(r.GetName(), labelResult).Inc()
+		metrics.SubroutineDuration.WithLabelValues(r.GetName()).Observe(time.Since(start).Seconds())
+	}()
 	operatorCfg := pmconfig.LoadConfigFromContext(ctx).(config.OperatorConfig)
 
 	scheme := r.client.Scheme()
@@ -94,7 +105,7 @@ func (r *ProvidersecretSubroutine) Process(
 	rootShard := &unstructured.Unstructured{}
 	rootShard.SetGroupVersionKind(schema.GroupVersionKind{Group: "operator.kcp.io", Version: "v1alpha1", Kind: "RootShard"})
 	// Wait for root shard to be ready
-	err := r.client.Get(ctx, types.NamespacedName{Name: operatorCfg.KCP.RootShardName, Namespace: operatorCfg.KCP.Namespace}, rootShard)
+	err = r.client.Get(ctx, types.NamespacedName{Name: operatorCfg.KCP.RootShardName, Namespace: operatorCfg.KCP.Namespace}, rootShard)
 	if err != nil || !matchesConditionWithStatus(rootShard, "Available", "True") {
 		log.Info().Msg("RootShard is not ready..")
 		return subroutines.StopWithRequeue(DefaultRequeueInterval, "RootShard is not ready"), nil

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/ocm"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 )
@@ -107,7 +108,16 @@ func getMetadataValue(obj *unstructured.Unstructured, key string) string {
 	return ""
 }
 
-func (r *ResourceSubroutine) Process(ctx context.Context, runtimeObj client.Object) (subroutineslib.Result, error) {
+func (r *ResourceSubroutine) Process(ctx context.Context, runtimeObj client.Object) (res subroutineslib.Result, err error) {
+	start := time.Now()
+	defer func() {
+		labelResult := "success"
+		if err != nil {
+			labelResult = "error"
+		}
+		metrics.SubroutineTotal.WithLabelValues(r.GetName(), labelResult).Inc()
+		metrics.SubroutineDuration.WithLabelValues(r.GetName()).Observe(time.Since(start).Seconds())
+	}()
 	inst := runtimeObj.(*unstructured.Unstructured)
 	log := logger.LoadLoggerFromContext(ctx).ChildLogger("name", r.GetName())
 

--- a/pkg/subroutines/wait.go
+++ b/pkg/subroutines/wait.go
@@ -3,6 +3,7 @@ package subroutines
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/platform-mesh/golang-commons/logger"
 	"github.com/platform-mesh/subroutines"
@@ -14,6 +15,7 @@ import (
 
 	corev1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
+	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
 )
 
 func NewWaitSubroutine(
@@ -52,7 +54,16 @@ func (r *WaitSubroutine) Finalize(
 
 func (r *WaitSubroutine) Process(
 	ctx context.Context, runtimeObj client.Object,
-) (subroutines.Result, error) {
+) (res subroutines.Result, err error) {
+	start := time.Now()
+	defer func() {
+		labelResult := "success"
+		if err != nil {
+			labelResult = "error"
+		}
+		metrics.SubroutineTotal.WithLabelValues(r.GetName(), labelResult).Inc()
+		metrics.SubroutineDuration.WithLabelValues(r.GetName()).Observe(time.Since(start).Seconds())
+	}()
 	instance := runtimeObj.(*corev1alpha1.PlatformMesh)
 	log := logger.LoadLoggerFromContext(ctx).ChildLogger("subroutine", r.GetName())
 


### PR DESCRIPTION
### Description
Adds a pkg/metrics package to platform-mesh-operator and wires custom Prometheus
metrics across the three main integration points of the service.

### Testing
`go test ./internal/metrics/... -v`