### PR TITLE
Add top-level permissions for the test source action

### DIFF
--- a/.github/workflows/job-golang-test-source.yml
+++ b/.github/workflows/job-golang-test-source.yml
@@ -7,6 +7,9 @@ on:
         type: string
         default: 'ubuntu-latest'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ inputs.runsOn }}


### PR DESCRIPTION
Scorecard requires setting the top-level permissions on every GitHub Action. Analyzing the action, I think `contents: read` should be enough for this action to work.