### PR TITLE
fix: remove explicit waiting on cert-manager

### DIFF
--- a/gotemplates/components/infra/helmreleases.yaml
+++ b/gotemplates/components/infra/helmreleases.yaml
@@ -48,6 +48,12 @@ spec:
 {{ toYaml $config.dependsOn | nindent 4 }}
   {{- end }}
   timeout: {{ $values.timeout | default "15m" }}
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
   values:
 {{ toYaml $config.values | nindent 4 }}
 ---

--- a/gotemplates/infra/infra/cert-manager/helmrelease.yaml
+++ b/gotemplates/infra/infra/cert-manager/helmrelease.yaml
@@ -21,6 +21,12 @@ spec:
   releaseName: {{ .certManager.name }}
   targetNamespace: {{ .certManager.targetNamespace }}
   timeout: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
   values:
 {{ toYaml .certManager.values | nindent 4 }}
 {{- end }}

--- a/gotemplates/infra/infra/etcd-druid/helmrelease.yaml
+++ b/gotemplates/infra/infra/etcd-druid/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
   targetNamespace: {{ .etcdDruid.targetNamespace }}
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
   timeout: 15m
   values:
     {{- toYaml .etcdDruid.values | nindent 4 }}

--- a/gotemplates/infra/infra/opentelemetry-operator/helmrelease.yaml
+++ b/gotemplates/infra/infra/opentelemetry-operator/helmrelease.yaml
@@ -23,6 +23,12 @@ spec:
   releaseName: {{ .opentelemetryOperator.name }}
   targetNamespace: {{ .opentelemetryOperator.targetNamespace }}
   timeout: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
 {{- if .opentelemetryOperator.values }}
   values:
 {{ toYaml .opentelemetryOperator.values | nindent 4 }}

--- a/gotemplates/infra/infra/prometheus-operator-crds/helmrelease.yaml
+++ b/gotemplates/infra/infra/prometheus-operator-crds/helmrelease.yaml
@@ -26,6 +26,12 @@ spec:
   releaseName: {{ .prometheusOperatorCRDs.name }}
   targetNamespace: {{ .prometheusOperatorCRDs.targetNamespace }}
   timeout: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
 {{- if .prometheusOperatorCRDs.values }}
   values:
 {{ toYaml .prometheusOperatorCRDs.values | nindent 4 }}

--- a/gotemplates/infra/infra/traefik/helmrelease-crds.yaml
+++ b/gotemplates/infra/infra/traefik/helmrelease-crds.yaml
@@ -26,4 +26,10 @@ spec:
   releaseName: {{ .traefikCRDs.name }}
   targetNamespace: {{ .traefikCRDs.targetNamespace }}
   timeout: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
 {{- end }}

--- a/gotemplates/infra/infra/traefik/helmrelease.yaml
+++ b/gotemplates/infra/infra/traefik/helmrelease.yaml
@@ -27,6 +27,12 @@ spec:
   releaseName: {{ .traefik.name }}
   targetNamespace: {{ .traefik.targetNamespace }}
   timeout: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 3
   values:
 {{ toYaml .traefik.values | nindent 4 }}
 {{- end }}

--- a/pkg/subroutines/deployment.go
+++ b/pkg/subroutines/deployment.go
@@ -236,6 +236,17 @@ func (r *DeploymentSubroutine) Process(ctx context.Context, runtimeObj client.Ob
 	}
 	log.Debug().Msg("Successfully rendered and applied components infra templates")
 
+	for _, crd := range []string{"issuers.cert-manager.io", "certificates.cert-manager.io"} {
+		established, err := isCRDEstablished(ctx, r.clientRuntime, crd)
+		if err != nil {
+			log.Error().Err(err).Str("crd", crd).Msg("Failed to check cert-manager CRD")
+			return subroutines.OK(), err
+		}
+		if !established {
+			return subroutines.StopWithRequeue(DefaultRequeueInterval, fmt.Sprintf("cert-manager CRD %s is not established", crd)), nil
+		}
+	}
+
 	_, oErr = r.manageAuthorizationWebhookSecrets(ctx, inst)
 	if oErr != nil {
 		log.Info().Msg("Failed to manage authorization webhook secrets")
@@ -1295,6 +1306,22 @@ func getDeploymentResource(ctx context.Context, client client.Client, resourceNa
 		return nil, err
 	}
 	return obj, nil
+}
+
+func isCRDEstablished(ctx context.Context, c client.Client, name string) (bool, error) {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, crd); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return matchesConditionWithStatus(crd, "Established", "True"), nil
 }
 
 func (r *DeploymentSubroutine) hasIstioProxyInjected(ctx context.Context, labelSelector, namespace string) (bool, *unstructured.Unstructured, error) {

--- a/pkg/subroutines/deployment.go
+++ b/pkg/subroutines/deployment.go
@@ -228,34 +228,7 @@ func (r *DeploymentSubroutine) Process(ctx context.Context, runtimeObj client.Ob
 	}
 	deploymentTech = strings.ToLower(deploymentTech)
 
-	// Wait for cert-manager to be ready before proceeding with component HelmReleases
-	rel, err := getDeploymentResource(ctx, r.clientInfra, "cert-manager", inst.Namespace, deploymentTech)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to get cert-manager resource")
-		return subroutines.OK(), err
-	}
-	if deploymentTech == deploymentTechArgoCD {
-		// For ArgoCD Applications, check status.sync.status and status.health.status directly
-		// ArgoCD Applications may not have conditions initially, so check status fields directly
-		syncStatus, found, _ := unstructured.NestedString(rel.Object, "status", "sync", "status")
-		healthStatus, healthFound, _ := unstructured.NestedString(rel.Object, "status", "health", "status")
-
-		if !found || syncStatus != "Synced" {
-			return subroutines.StopWithRequeue(DefaultRequeueInterval, "cert-manager Application is not synced"), nil
-		}
-		if !healthFound || healthStatus != "Healthy" {
-			return subroutines.StopWithRequeue(DefaultRequeueInterval, "cert-manager Application is not healthy"), nil
-		}
-	}
-
-	if deploymentTech == deploymentTechFluxCD {
-		// For FluxCD HelmReleases, check Ready condition
-		if !matchesConditionWithStatus(rel, "Ready", "True") {
-			return subroutines.StopWithRequeue(DefaultRequeueInterval, "cert-manager Release is not ready"), nil
-		}
-	}
-
-	// Render and apply components infra templates (HelmReleases for services) after cert-manager is ready
+	// Render and apply components infra templates (HelmReleases for services)
 	oErr = r.renderAndApplyComponentsInfraTemplates(ctx, inst, templateVars)
 	if oErr != nil {
 		log.Error().Err(oErr).Msg("Failed to render and apply components infra templates")

--- a/pkg/subroutines/deployment_test.go
+++ b/pkg/subroutines/deployment_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
@@ -243,6 +244,22 @@ func (s *DeploymentProcessTestSuite) newReadyFrontProxy(namespace string) *unstr
 	return obj
 }
 
+func (s *DeploymentProcessTestSuite) newEstablishedCRD(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"})
+	obj.SetName(name)
+	_ = unstructured.SetNestedSlice(obj.Object, []interface{}{
+		map[string]interface{}{"type": "Established", "status": "True"},
+	}, "status", "conditions")
+	return obj
+}
+
+func (s *DeploymentProcessTestSuite) seedCertManagerCRDs(ctx context.Context, cl client.Client) {
+	s.Require().NoError(cl.Create(ctx, s.newEstablishedCRD("issuers.cert-manager.io")))
+	s.Require().NoError(cl.Create(ctx, s.newEstablishedCRD("certificates.cert-manager.io")))
+}
+
+
 func (s *DeploymentProcessTestSuite) Test_Process_FluxCD_HappyPath() {
 	ns := "platform-mesh-system"
 	operatorCfg := s.newOperatorConfig()
@@ -274,6 +291,7 @@ func (s *DeploymentProcessTestSuite) Test_Process_FluxCD_HappyPath() {
 	s.Require().NoError(cl.Create(ctx, s.newFluxCDReadyCertManager(ns)))
 	s.Require().NoError(cl.Create(ctx, s.newReadyRootShard(ns)))
 	s.Require().NoError(cl.Create(ctx, s.newReadyFrontProxy(ns)))
+	s.seedCertManagerCRDs(ctx, cl)
 
 	sub := &DeploymentSubroutine{
 		clientRuntime:            cl,
@@ -321,6 +339,7 @@ func (s *DeploymentProcessTestSuite) Test_Process_ArgoCD_HappyPath() {
 	s.Require().NoError(cl.Create(ctx, s.newArgoCDReadyCertManager(ns)))
 	s.Require().NoError(cl.Create(ctx, s.newReadyRootShard(ns)))
 	s.Require().NoError(cl.Create(ctx, s.newReadyFrontProxy(ns)))
+	s.seedCertManagerCRDs(ctx, cl)
 
 	sub := &DeploymentSubroutine{
 		clientRuntime:            cl,
@@ -338,7 +357,7 @@ func (s *DeploymentProcessTestSuite) Test_Process_ArgoCD_HappyPath() {
 	s.True(result.IsContinue(), "expected OK/continue result, got stop")
 }
 
-func (s *DeploymentProcessTestSuite) Test_Process_CertManagerNotReady_FluxCD() {
+func (s *DeploymentProcessTestSuite) Test_Process_CertManagerCRDsNotEstablished_FluxCD() {
 	ns := "platform-mesh-system"
 	operatorCfg := s.newOperatorConfig()
 	ctx := s.newContext(operatorCfg)
@@ -355,21 +374,15 @@ func (s *DeploymentProcessTestSuite) Test_Process_CertManagerNotReady_FluxCD() {
 		Data:       map[string]string{profileConfigMapKey: testProfileFluxCD},
 	}
 
-	// cert-manager exists but is NOT ready
-	certMgr := &unstructured.Unstructured{}
-	certMgr.SetGroupVersionKind(schema.GroupVersionKind{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"})
-	certMgr.SetName("cert-manager")
-	certMgr.SetNamespace(ns)
-	_ = unstructured.SetNestedSlice(certMgr.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False"},
-	}, "status", "conditions")
-
 	cl := fake.NewClientBuilder().
 		WithScheme(s.scheme).
 		WithObjects(inst, profileCM).
 		WithStatusSubresource(inst).
 		Build()
-	s.Require().NoError(cl.Create(ctx, certMgr))
+	s.Require().NoError(cl.Create(ctx, s.newFluxCDReadyCertManager(ns)))
+	s.Require().NoError(cl.Create(ctx, s.newReadyRootShard(ns)))
+	s.Require().NoError(cl.Create(ctx, s.newReadyFrontProxy(ns)))
+	// cert-manager CRDs are NOT seeded — Process must stop and requeue.
 
 	sub := &DeploymentSubroutine{
 		clientRuntime:            cl,
@@ -384,7 +397,7 @@ func (s *DeploymentProcessTestSuite) Test_Process_CertManagerNotReady_FluxCD() {
 	result, err := sub.Process(ctx, inst)
 
 	s.NoError(err)
-	s.False(result.IsContinue(), "expected StopWithRequeue when cert-manager not ready")
+	s.False(result.IsContinue(), "expected StopWithRequeue when cert-manager CRDs are not established")
 }
 
 func (s *DeploymentProcessTestSuite) Test_Process_MissingProfile() {


### PR DESCRIPTION
Remove explicit waiting on `cert-manager` in the operator. That would enable the operator to support envs where cert-manager is installed separately.