### PR TITLE
feat: use scoped kubeconfigs for rebac, extension-manager, and iam-service

### DIFF
--- a/pkg/subroutines/defaults.go
+++ b/pkg/subroutines/defaults.go
@@ -29,9 +29,10 @@ var DefaultProviderConnections = []corev1alpha1.ProviderConnection{
 		AdminAuth: ptr.To(true),
 	},
 	{
-		Path:      "root:platform-mesh-system",
-		Secret:    "rebac-authz-webhook-kubeconfig",
-		AdminAuth: ptr.To(true),
+		Path:          "root:platform-mesh-system",
+		Secret:        "rebac-authz-webhook-kubeconfig",
+		APIExportName: ptr.To("core.platform-mesh.io"),
+		AdminAuth:     ptr.To(false),
 	},
 	{
 		Path:      "root:platform-mesh-system",
@@ -51,12 +52,14 @@ var DefaultProviderConnections = []corev1alpha1.ProviderConnection{
 	{
 		Path:          "root:platform-mesh-system",
 		Secret:        "extension-manager-operator-kubeconfig",
-		AdminAuth:     ptr.To(true),
+		APIExportName: ptr.To("core.platform-mesh.io"),
+		AdminAuth:     ptr.To(false),
 	},
 	{
 		Path:          "root:platform-mesh-system",
 		Secret:        "iam-service-kubeconfig",
-		AdminAuth:     ptr.To(true),
+		APIExportName: ptr.To("core.platform-mesh.io"),
+		AdminAuth:     ptr.To(false),
 	},
 	{
 		Path:      "root:orgs",


### PR DESCRIPTION
Switch default provider connections for rebac-authz-webhook, extension-manager-operator, and iam-service to scoped kubeconfig. It was enabled before, but didn't work for sharding to a kcp bug, which now has been resolved.