### PR TITLE
feat: add templates for redirect uris and post logout uris

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,9 @@ type KCPConfig struct {
 }
 
 type IDPConfig struct {
-	RegistrationAllowed bool
+	RegistrationAllowed                     bool
+	WelcomeAdditionalRedirectUris           []string
+	WelcomeAdditionalPostLogoutRedirectUris []string
 }
 
 type DeploymentSubroutineConfig struct {
@@ -145,6 +147,8 @@ func (c *OperatorConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KCP.ClusterAdminSecretName, "kcp-cluster-admin-secret-name", c.KCP.ClusterAdminSecretName, "Set cluster-admin secret name")
 
 	fs.BoolVar(&c.IDP.RegistrationAllowed, "idp-registration-allowed", c.IDP.RegistrationAllowed, "Allow IDP registration")
+	fs.StringSliceVar(&c.IDP.WelcomeAdditionalRedirectUris, "idp-welcome-additional-redirect-uris", c.IDP.WelcomeAdditionalRedirectUris, "Additional redirect URIs for the welcome client (comma-separated)")
+	fs.StringSliceVar(&c.IDP.WelcomeAdditionalPostLogoutRedirectUris, "idp-welcome-additional-post-logout-redirect-uris", c.IDP.WelcomeAdditionalPostLogoutRedirectUris, "Additional post-logout redirect URIs for the welcome client (comma-separated)")
 
 	fs.BoolVar(&c.Subroutines.Deployment.Enabled, "subroutines-deployment-enabled", c.Subroutines.Deployment.Enabled, "Enable deployment subroutine")
 	fs.StringVar(&c.Subroutines.Deployment.AuthorizationWebhookSecretName, "authorization-webhook-secret-name", c.Subroutines.Deployment.AuthorizationWebhookSecretName, "Authorization webhook secret name")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,6 +50,8 @@ func TestOperatorConfigAddFlags(t *testing.T) {
 		"--kcp-front-proxy-port=7443",
 		"--kcp-cluster-admin-secret-name=custom-admin-secret",
 		"--idp-registration-allowed=true",
+		"--idp-welcome-additional-redirect-uris=https://extra.example.com/callback,https://other.example.com/callback",
+		"--idp-welcome-additional-post-logout-redirect-uris=https://extra.example.com/logout",
 		"--subroutines-deployment-enabled=false",
 		"--authorization-webhook-secret-name=authz-secret",
 		"--authorization-webhook-secret-ca-name=authz-ca",
@@ -71,6 +73,8 @@ func TestOperatorConfigAddFlags(t *testing.T) {
 	assert.Equal(t, "7443", cfg.KCP.FrontProxyPort)
 	assert.Equal(t, "custom-admin-secret", cfg.KCP.ClusterAdminSecretName)
 	assert.True(t, cfg.IDP.RegistrationAllowed)
+	assert.Equal(t, []string{"https://extra.example.com/callback", "https://other.example.com/callback"}, cfg.IDP.WelcomeAdditionalRedirectUris)
+	assert.Equal(t, []string{"https://extra.example.com/logout"}, cfg.IDP.WelcomeAdditionalPostLogoutRedirectUris)
 
 	assert.False(t, cfg.Subroutines.Deployment.Enabled)
 	assert.Equal(t, "authz-secret", cfg.Subroutines.Deployment.AuthorizationWebhookSecretName)

--- a/manifests/kcp/03-platform-mesh-system/welcome-ipc.yaml
+++ b/manifests/kcp/03-platform-mesh-system/welcome-ipc.yaml
@@ -9,8 +9,14 @@ spec:
     clientName: welcome
     postLogoutRedirectUris:
     - https://{{ .baseDomainPort }}/logout*
+    {{- range .welcomeAdditionalPostLogoutRedirectUris }}
+    - {{ . }}
+    {{- end }}
     redirectUris:
     - https://{{ .baseDomainPort }}/callback*
+    {{- range .welcomeAdditionalRedirectUris }}
+    - {{ . }}
+    {{- end }}
     secretRef:
       name: portal-client-secret-welcome
       namespace: default

--- a/pkg/subroutines/kcpsetup.go
+++ b/pkg/subroutines/kcpsetup.go
@@ -176,6 +176,8 @@ func (r *KcpsetupSubroutine) createKcpResources(ctx context.Context, config *res
 	templateData["featureDisableContentConfigurations"] = HasFeatureToggle(inst, "feature-disable-contentconfigurations")
 	templateData["featureEnableTerminalControllerManager"] = HasFeatureToggle(inst, "feature-enable-terminal-controller-manager")
 	templateData["registrationAllowed"] = r.cfg.IDP.RegistrationAllowed
+	templateData["welcomeAdditionalRedirectUris"] = r.cfg.IDP.WelcomeAdditionalRedirectUris
+	templateData["welcomeAdditionalPostLogoutRedirectUris"] = r.cfg.IDP.WelcomeAdditionalPostLogoutRedirectUris
 
 	pmSystemClient, err := r.kcpHelper.NewKcpClient(config, "root:platform-mesh-system")
 	if err != nil {


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

This PR add template variables for additional redirect and post logout uris in welcome IDP spec. It addresses this issue https://github.com/platform-mesh/platform-mesh-operator/issues/327