### PR TITLE
fix: use-correct-client-for-kcp-interaction

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -96,10 +96,11 @@ func RunController(_ *cobra.Command, _ []string) { // coverage-ignore
 	log.Info().Msg("Starting manager")
 
 	restCfg := ctrl.GetConfigOrDie()
+	var runtimeClient client.Client
 	if operatorCfg.RemoteRuntime.IsEnabled() {
 		setupLog.Info("Remote PlatformMesh reconciliation enabled, kubeconfig: " + operatorCfg.RemoteRuntime.Kubeconfig)
 		var err error
-		_, restCfg, err = subroutines.GetClientAndRestConfig(operatorCfg.RemoteRuntime.Kubeconfig)
+		runtimeClient, restCfg, err = subroutines.GetClientAndRestConfig(operatorCfg.RemoteRuntime.Kubeconfig)
 		if err != nil {
 			setupLog.Error(err, "unable to create PlatformMesh client")
 			os.Exit(1)
@@ -201,7 +202,7 @@ func RunController(_ *cobra.Command, _ []string) { // coverage-ignore
 		os.Exit(1)
 	}
 
-	go startProvidersOperator(ctx, clientInfra, mgr)
+	go startProvidersOperator(ctx, runtimeClient, mgr)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -96,7 +96,11 @@ func RunController(_ *cobra.Command, _ []string) { // coverage-ignore
 	log.Info().Msg("Starting manager")
 
 	restCfg := ctrl.GetConfigOrDie()
-	var runtimeClient client.Client
+	runtimeClient, err := client.New(restCfg, client.Options{Scheme: subroutines.GetClientScheme()})
+	if err != nil {
+		setupLog.Error(err, "unable to create PlatformMesh client")
+		os.Exit(1)
+	}
 	if operatorCfg.RemoteRuntime.IsEnabled() {
 		setupLog.Info("Remote PlatformMesh reconciliation enabled, kubeconfig: " + operatorCfg.RemoteRuntime.Kubeconfig)
 		var err error


### PR DESCRIPTION
When using a 2-cluster remote setup (one infra-cluster that hosts the operator and all the argo cd apps and resources) we ran into the following error:

```
Failed to get secret: secrets \"kcp-cluster-admin-client-cert\" not found"
```

That secret was created, but on the runtime cluster!

As stated in the documentation https://github.com/platform-mesh/platform-mesh-operator#remote-deployment the `--remote-infra-kubeconfig` key must only be set if the infra cluster is different than the cluster the operator is deployed to. 

KCP is always created in the remote runtime cluster and thus the lookup for the secret must also go towards the runtime cluster and not fall-back to default (i.e. the cluster the operator is deployed to in a remote setup)