### PR TITLE
feat: add deploymentNamespace for configurable deployment CR namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ gotemplates/
 | Variable | Source |
 |----------|--------|
 | `releaseNamespace` | PlatformMesh instance namespace |
-| `helmReleaseNamespace` | Same as releaseNamespace |
+| `deploymentNamespace` | Profile `infra.deploymentNamespace` (falls back to instance namespace) |
+| `helmReleaseNamespace` | Same as `deploymentNamespace` |
 | `deploymentTechnology` | Profile or templateVars (`fluxcd` / `argocd`) |
 | `kubeConfigEnabled` | `true` if `--remote-runtime-kubeconfig` is set |
 | `kubeConfigSecretName` | `--remote-runtime-infra-secret-name` |
@@ -397,6 +398,7 @@ gotemplates/
 | `values.services.<name>.enabled` | Per-service enabled flag |
 | `values.services.<name>.values` | Per-service Helm values |
 | `releaseNamespace` | PlatformMesh instance namespace |
+| `deploymentNamespace` | Profile `components.deploymentNamespace` (falls back to instance namespace) |
 | `kubeConfigEnabled` | Remote runtime flag |
 | `kubeConfigSecretName` / `kubeConfigSecretKey` | Remote runtime secret ref |
 | `deploymentTechnology` | `fluxcd` or `argocd` |
@@ -404,6 +406,25 @@ gotemplates/
 | `baseDomain` | From `spec.exposure.baseDomain` |
 | `port` | From `spec.exposure.port` |
 | `baseDomainWithPort` | Combined domain:port (port omitted if 443) |
+
+##### deploymentNamespace (Two-Cluster Setup)
+
+When ArgoCD runs on a separate infra cluster, deployment CRs (Application / HelmRelease) must be created in a different namespace than where workloads deploy. Set `deploymentNamespace` in the profile to control where these CRs are placed:
+
+```yaml
+# profile.yaml
+infra:
+  deploymentNamespace: argocd-apps    # namespace on infra cluster where ArgoCD watches
+  deploymentTechnology: argocd
+components:
+  deploymentNamespace: argocd-apps    # same — controls Application CR metadata.namespace
+  services:
+    my-service:
+      enabled: true
+      targetNamespace: platform-mesh-system  # where workloads actually deploy
+```
+
+Result: `metadata.namespace: argocd-apps` (where the CR lives), `spec.destination.namespace: platform-mesh-system` (where workloads deploy). If omitted, both default to the PlatformMesh CR namespace.
 
 **Runtime templates** (`gotemplates/infra/runtime/` and `gotemplates/components/runtime/`) additionally receive:
 

--- a/gotemplates/components/infra/applications.yaml
+++ b/gotemplates/components/infra/applications.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ $service}}
-  namespace: {{ $.releaseNamespace }}
+  namespace: {{ $.deploymentNamespace }}
   labels:
     core.platform-mesh.io/operator-created: "true"
   annotations:

--- a/gotemplates/components/infra/helmreleases.yaml
+++ b/gotemplates/components/infra/helmreleases.yaml
@@ -5,7 +5,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ $service }}
-  namespace: {{ $.releaseNamespace }}
+  namespace: {{ $.deploymentNamespace }}
   labels:
     core.platform-mesh.io/operator-created: "true"
 spec:
@@ -38,7 +38,7 @@ spec:
   chartRef:
     kind: OCIRepository
     name: {{ $service }}
-    namespace: {{ $.releaseNamespace }}
+    namespace: {{ $.deploymentNamespace }}
   {{- end }}
   interval: 1m
   releaseName: {{ $service }}

--- a/pkg/subroutines/deployment.go
+++ b/pkg/subroutines/deployment.go
@@ -374,8 +374,10 @@ func (r *DeploymentSubroutine) templateVarsFromProfileInfra(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to merge infra profile with templateVars")
 	}
 
-	// Ensure helmReleaseNamespace is set (from templateVars or use releaseNamespace)
-	if _, ok := tmplVars["helmReleaseNamespace"]; !ok {
+	// Ensure helmReleaseNamespace is set: prefer deploymentNamespace, then existing helmReleaseNamespace, then inst.Namespace
+	if deployNs, ok := tmplVars["deploymentNamespace"].(string); ok && deployNs != "" {
+		tmplVars["helmReleaseNamespace"] = deployNs
+	} else if _, ok := tmplVars["helmReleaseNamespace"]; !ok {
 		tmplVars["helmReleaseNamespace"] = inst.Namespace
 	}
 
@@ -498,7 +500,11 @@ func (r *DeploymentSubroutine) buildRuntimeTemplateVars(ctx context.Context, ins
 
 	// Add instance-specific fields
 	baseVars["releaseNamespace"] = inst.Namespace
-	baseVars["helmReleaseNamespace"] = inst.Namespace // Some templates use this
+	if deployNs, ok := baseVars["deploymentNamespace"].(string); ok && deployNs != "" {
+		baseVars["helmReleaseNamespace"] = deployNs
+	} else {
+		baseVars["helmReleaseNamespace"] = inst.Namespace
+	}
 	baseVars["kubeConfigEnabled"] = r.cfgOperator.RemoteRuntime.IsEnabled()
 	if r.cfgOperator.RemoteRuntime.IsEnabled() {
 		baseVars["kubeConfigSecretName"] = r.cfgOperator.RemoteRuntime.InfraSecretName
@@ -634,6 +640,12 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 	data := map[string]interface{}{
 		"values":           values,
 		"releaseNamespace": inst.Namespace,
+	}
+	// deploymentNamespace: where deployment CRs live (configurable via profile)
+	if deployNs, ok := values["deploymentNamespace"].(string); ok && deployNs != "" {
+		data["deploymentNamespace"] = deployNs
+	} else {
+		data["deploymentNamespace"] = inst.Namespace
 	}
 
 	// Add kubeConfig fields for remote PlatformMesh support

--- a/pkg/subroutines/deployment_test.go
+++ b/pkg/subroutines/deployment_test.go
@@ -201,6 +201,18 @@ components:
   services: {}
 `
 
+const testProfileArgoCDWithDeploymentNamespace = `
+infra:
+  deploymentTechnology: argocd
+  deploymentNamespace: custom-deploy-ns
+  certManager:
+    enabled: true
+    name: cert-manager
+    targetNamespace: cert-manager
+components:
+  services: {}
+`
+
 func (s *DeploymentProcessTestSuite) newFluxCDReadyCertManager(namespace string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"})
@@ -474,4 +486,58 @@ func (s *DeploymentProcessTestSuite) Test_Process_RootShardNotReady() {
 
 	s.NoError(err)
 	s.False(result.IsContinue(), "expected StopWithRequeue when RootShard not found")
+}
+
+func (s *DeploymentProcessTestSuite) Test_Process_DeploymentNamespace() {
+	ns := "platform-mesh-system"
+	operatorCfg := s.newOperatorConfig()
+	ctx := s.newContext(operatorCfg)
+
+	inst := &corev1alpha1.PlatformMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-mesh", Namespace: ns},
+		Spec: corev1alpha1.PlatformMeshSpec{
+			Exposure: &corev1alpha1.ExposureConfig{
+				BaseDomain: "localhost",
+				Port:       8443,
+				Protocol:   "https",
+			},
+		},
+	}
+
+	profileCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-mesh-profile", Namespace: ns},
+		Data:       map[string]string{profileConfigMapKey: testProfileArgoCDWithDeploymentNamespace},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s.scheme).
+		WithObjects(inst, profileCM).
+		WithStatusSubresource(inst).
+		Build()
+
+	s.Require().NoError(cl.Create(ctx, s.newArgoCDReadyCertManager("custom-deploy-ns")))
+	s.Require().NoError(cl.Create(ctx, s.newReadyRootShard(ns)))
+	s.Require().NoError(cl.Create(ctx, s.newReadyFrontProxy(ns)))
+	s.seedCertManagerCRDs(ctx, cl)
+
+	sub := &DeploymentSubroutine{
+		clientRuntime:            cl,
+		clientInfra:              cl,
+		cfg:                      &pmconfig.CommonServiceConfig{IsLocal: true},
+		cfgOperator:              &operatorCfg,
+		gotemplatesInfraDir:      filepath.Join(s.tmpDir, "gotemplates/infra"),
+		gotemplatesComponentsDir: filepath.Join(s.tmpDir, "gotemplates/components"),
+		workspaceDirectory:       filepath.Join(s.tmpDir, "manifests/k8s"),
+	}
+
+	result, err := sub.Process(ctx, inst)
+
+	s.NoError(err)
+	s.True(result.IsContinue(), "expected OK/continue result, got stop")
+
+	// Verify the infra template rendered with helmReleaseNamespace = custom-deploy-ns
+	var cm corev1.ConfigMap
+	err = cl.Get(ctx, client.ObjectKey{Name: "cert-manager-argo-rendered", Namespace: "custom-deploy-ns"}, &cm)
+	s.NoError(err, "ConfigMap should exist in custom-deploy-ns (the deploymentNamespace)")
+	s.Equal("custom-deploy-ns", cm.Namespace)
 }


### PR DESCRIPTION
## Summary
- Adds `deploymentNamespace` template variable controlling where ArgoCD Application / HelmRelease CRs are created (`metadata.namespace`)
- Separate from `releaseNamespace` which controls where workloads deploy (`spec.destination.namespace` / `targetNamespace`)
- Configured via profile ConfigMap (`infra.deploymentNamespace` / `components.deploymentNamespace`)
- Falls back to PlatformMesh CR namespace if not set (no breaking change)

## Use Case
Two-cluster setup where ArgoCD on an infra cluster watches a specific namespace for Application CRs, while workloads deploy to a different namespace on the runtime cluster.

## Test plan
- [x] Unit test `Test_Process_DeploymentNamespace` verifying `helmReleaseNamespace` set from profile
- [x] Local operator against dxp-infra + d1eu1 clusters with debug label isolation
- [x] Verified Application CR created in correct namespace on infra cluster
- [x] Verified `spec.destination.namespace` remains as `releaseNamespace`
- [x] OCM resources correctly stay in `releaseNamespace` on runtime cluster