### PR TITLE
fix: include deploymentNamespace in AppProject sourceNamespaces

### DIFF
--- a/gotemplates/infra/infra/appproject.yaml
+++ b/gotemplates/infra/infra/appproject.yaml
@@ -19,6 +19,9 @@ spec:
       server: {{ .destinationServer | default "https://kubernetes.default.svc" }}
   sourceNamespaces:
     - {{ .releaseNamespace }}
+{{- if and .helmReleaseNamespace (ne .helmReleaseNamespace .releaseNamespace) }}
+    - {{ .helmReleaseNamespace }}
+{{- end }}
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'


### PR DESCRIPTION
## Summary
- Adds `helmReleaseNamespace` to AppProject `sourceNamespaces` when it differs from `releaseNamespace`
- Without this, ArgoCD rejects apps in the deployment namespace with "not permitted to use project"

## Context
When `infra.deploymentNamespace` is set (e.g. `dxp-dev`), Application CRs are created in that namespace instead of `platform-mesh-system`. The AppProject must permit that namespace as a source.

Follows up on PR #732 which added `deploymentNamespace` support.

## Test plan
- [ ] Deploy operator with this fix
- [ ] Verify AppProject includes both `platform-mesh-system` and `dxp-dev` in sourceNamespaces
- [ ] Verify apps in `dxp-dev` are no longer rejected by ArgoCD