### PR TITLE
fix: resolve ArgoCD apps in deploymentNamespace from profile

### DIFF
--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -22,7 +22,10 @@ import (
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 )
 
-const requeueShort = 5 * time.Second
+const (
+	requeueShort       = 5 * time.Second
+	profileConfigMapKey = "profile.yaml"
+)
 
 var profileConfigMapNames = []string{"platform-mesh-profile", "platform-mesh-system-profile"}
 
@@ -673,7 +676,7 @@ func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, res
 			continue
 		}
 
-		profileYAML, ok := configMap.Data["profile.yaml"]
+		profileYAML, ok := configMap.Data[profileConfigMapKey]
 		if !ok {
 			continue
 		}
@@ -743,11 +746,11 @@ func (r *ResourceSubroutine) getDeploymentTechnologyFromConfigMapDirect(ctx cont
 			continue
 		}
 
-		log.Info().Str("configMap", cmName).Str("namespace", namespace).Msg("Found ConfigMap, reading profile.yaml")
+		log.Info().Str("configMap", cmName).Str("namespace", namespace).Msg("Found ConfigMap, reading profile")
 
-		profileYAML, ok := configMap.Data["profile.yaml"]
+		profileYAML, ok := configMap.Data[profileConfigMapKey]
 		if !ok {
-			log.Warn().Str("configMap", cmName).Msg("ConfigMap found but profile.yaml key missing")
+			log.Warn().Str("configMap", cmName).Msg("ConfigMap found but profile key missing")
 			continue
 		}
 

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -10,6 +10,7 @@ import (
 	subroutineslib "github.com/platform-mesh/subroutines"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -673,6 +674,9 @@ func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, res
 	for _, cmName := range configMapNames {
 		configMap := &corev1.ConfigMap{}
 		if err := r.clientRuntime.Get(ctx, types.NamespacedName{Name: cmName, Namespace: resourceNamespace}, configMap); err != nil {
+			if !apierrors.IsNotFound(err) {
+				log.Warn().Err(err).Str("configMap", cmName).Str("namespace", resourceNamespace).Msg("Unexpected error reading profile ConfigMap")
+			}
 			continue
 		}
 
@@ -742,7 +746,11 @@ func (r *ResourceSubroutine) getDeploymentTechnologyFromConfigMapDirect(ctx cont
 	for _, cmName := range configMapNames {
 		configMap := &corev1.ConfigMap{}
 		if err := r.clientRuntime.Get(ctx, types.NamespacedName{Name: cmName, Namespace: namespace}, configMap); err != nil {
-			log.Debug().Err(err).Str("configMap", cmName).Str("namespace", namespace).Msg("ConfigMap not found, trying next")
+			if apierrors.IsNotFound(err) {
+				log.Debug().Str("configMap", cmName).Str("namespace", namespace).Msg("Profile ConfigMap not found, trying next")
+			} else {
+				log.Warn().Err(err).Str("configMap", cmName).Str("namespace", namespace).Msg("Unexpected error reading profile ConfigMap")
+			}
 			continue
 		}
 

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -214,7 +214,10 @@ func (r *ResourceSubroutine) Process(ctx context.Context, runtimeObj client.Obje
 }
 
 func (r *ResourceSubroutine) updateHelmReleaseWithImageTag(ctx context.Context, inst *unstructured.Unstructured, log *logger.Logger) (subroutineslib.Result, error) {
-	defaultNamespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	defaultNamespace, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
 	name, namespace := parseNamespacedName(getMetadataValue(inst, "for"), inst.GetName(), defaultNamespace)
 	updatePath := append([]string{"spec", "values"}, parsePath(getMetadataValue(inst, "path"), "image.tag")...)
 	versionPath := parsePath(getMetadataValue(inst, "version-path"), "status.resource.version")
@@ -262,7 +265,10 @@ func (r *ResourceSubroutine) updateArgoCDApplication(ctx context.Context, inst *
 	}
 	log.Debug().Str("repoURL", repoURL).Str("targetRevision", targetRevision).Str("type", chartType).Msg("Resolved ArgoCD source")
 
-	appNamespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	appNamespace, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
 	appName := trimPMSuffixes(inst.GetName())
 	existingApp := &unstructured.Unstructured{}
 	existingApp.SetGroupVersionKind(argocdApplicationGvk)
@@ -373,7 +379,10 @@ func firstNonEmpty(values ...string) string {
 }
 
 func (r *ResourceSubroutine) updateArgoCDApplicationHelmValues(ctx context.Context, inst *unstructured.Unstructured, log *logger.Logger) (subroutineslib.Result, error) {
-	defaultNamespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	defaultNamespace, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
 	appName, appNamespace := parseNamespacedName(getMetadataValue(inst, "for"), inst.GetName(), defaultNamespace)
 	updatePath := parsePath(getMetadataValue(inst, "path"), "image.tag")
 	pathStr := strings.Join(updatePath, ".")
@@ -506,7 +515,10 @@ func (r *ResourceSubroutine) updateHelmRelease(ctx context.Context, inst *unstru
 	}
 
 	name := trimPMSuffixes(inst.GetName())
-	namespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	namespace, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
 
 	// GET the existing HelmRelease so we can do a merge update instead of SSA,
 	// which would require a full valid spec (chart.spec.chart, chart.spec.sourceRef, etc.).
@@ -541,7 +553,11 @@ func (r *ResourceSubroutine) updateHelmRepository(ctx context.Context, inst *uns
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(helmRepoGvk)
 	obj.SetName(trimPMSuffixes(inst.GetName()))
-	obj.SetNamespace(r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log))
+	ns, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
+	obj.SetNamespace(ns)
 	_ = unstructured.SetNestedField(obj.Object, url, "spec", "url")
 	_ = unstructured.SetNestedField(obj.Object, "generic", "spec", "provider")
 	_ = unstructured.SetNestedField(obj.Object, "5m", "spec", "interval")
@@ -589,7 +605,11 @@ func (r *ResourceSubroutine) updateOciRepo(ctx context.Context, inst *unstructur
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(ociRepoGvk)
 	obj.SetName(trimPMSuffixes(inst.GetName()))
-	obj.SetNamespace(r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log))
+	ns, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
+	obj.SetNamespace(ns)
 
 	// Set desired fields
 	if err := unstructured.SetNestedField(obj.Object, version, "spec", "ref", "tag"); err != nil {
@@ -641,7 +661,11 @@ func (r *ResourceSubroutine) updateGitRepo(ctx context.Context, inst *unstructur
 
 	obj.SetGroupVersionKind(gitRepoGvk)
 	obj.SetName(trimPMSuffixes(inst.GetName()))
-	obj.SetNamespace(r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log))
+	ns, err := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	if err != nil {
+		return subroutineslib.OK(), err
+	}
+	obj.SetNamespace(ns)
 
 	// Set desired fields
 	if err := unstructured.SetNestedField(obj.Object, commit, "spec", "ref", "commit"); err != nil {
@@ -668,16 +692,16 @@ func (r *ResourceSubroutine) updateGitRepo(ctx context.Context, inst *unstructur
 // getAppNamespaceFromProfile returns the namespace where Application CRs are deployed.
 // If the profile sets a deploymentNamespace (infra or components section), use that.
 // Otherwise fall back to the Resource CR's own namespace.
-func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, resourceNamespace string, log *logger.Logger) string {
+func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, resourceNamespace string, log *logger.Logger) (string, error) {
 	configMapNames := profileConfigMapNames
 
 	for _, cmName := range configMapNames {
 		configMap := &corev1.ConfigMap{}
 		if err := r.clientRuntime.Get(ctx, types.NamespacedName{Name: cmName, Namespace: resourceNamespace}, configMap); err != nil {
-			if !apierrors.IsNotFound(err) {
-				log.Warn().Err(err).Str("configMap", cmName).Str("namespace", resourceNamespace).Msg("Unexpected error reading profile ConfigMap")
+			if apierrors.IsNotFound(err) {
+				continue
 			}
-			continue
+			return "", fmt.Errorf("failed to read profile ConfigMap %s/%s: %w", resourceNamespace, cmName, err)
 		}
 
 		profileYAML, ok := configMap.Data[profileConfigMapKey]
@@ -693,19 +717,19 @@ func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, res
 		if infra, ok := profile["infra"].(map[string]interface{}); ok {
 			if ns, ok := infra["deploymentNamespace"].(string); ok && ns != "" {
 				log.Debug().Str("appNamespace", ns).Str("source", "infra.deploymentNamespace").Msg("Resolved app namespace from profile")
-				return ns
+				return ns, nil
 			}
 		}
 
 		if components, ok := profile["components"].(map[string]interface{}); ok {
 			if ns, ok := components["deploymentNamespace"].(string); ok && ns != "" {
 				log.Debug().Str("appNamespace", ns).Str("source", "components.deploymentNamespace").Msg("Resolved app namespace from profile")
-				return ns
+				return ns, nil
 			}
 		}
 	}
 
-	return resourceNamespace
+	return resourceNamespace, nil
 }
 
 func (r *ResourceSubroutine) getDeploymentTechnologyFromProfile(ctx context.Context, namespace string, log *logger.Logger) (string, error) {
@@ -748,10 +772,9 @@ func (r *ResourceSubroutine) getDeploymentTechnologyFromConfigMapDirect(ctx cont
 		if err := r.clientRuntime.Get(ctx, types.NamespacedName{Name: cmName, Namespace: namespace}, configMap); err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Debug().Str("configMap", cmName).Str("namespace", namespace).Msg("Profile ConfigMap not found, trying next")
-			} else {
-				log.Warn().Err(err).Str("configMap", cmName).Str("namespace", namespace).Msg("Unexpected error reading profile ConfigMap")
+				continue
 			}
-			continue
+			return "", fmt.Errorf("failed to read profile ConfigMap %s/%s: %w", namespace, cmName, err)
 		}
 
 		log.Info().Str("configMap", cmName).Str("namespace", namespace).Msg("Found ConfigMap, reading profile")

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -208,7 +208,8 @@ func (r *ResourceSubroutine) Process(ctx context.Context, runtimeObj client.Obje
 }
 
 func (r *ResourceSubroutine) updateHelmReleaseWithImageTag(ctx context.Context, inst *unstructured.Unstructured, log *logger.Logger) (subroutineslib.Result, error) {
-	name, namespace := parseNamespacedName(getMetadataValue(inst, "for"), inst.GetName(), inst.GetNamespace())
+	defaultNamespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	name, namespace := parseNamespacedName(getMetadataValue(inst, "for"), inst.GetName(), defaultNamespace)
 	updatePath := append([]string{"spec", "values"}, parsePath(getMetadataValue(inst, "path"), "image.tag")...)
 	versionPath := parsePath(getMetadataValue(inst, "version-path"), "status.resource.version")
 
@@ -255,12 +256,13 @@ func (r *ResourceSubroutine) updateArgoCDApplication(ctx context.Context, inst *
 	}
 	log.Debug().Str("repoURL", repoURL).Str("targetRevision", targetRevision).Str("type", chartType).Msg("Resolved ArgoCD source")
 
+	appNamespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
 	appName := trimPMSuffixes(inst.GetName())
 	existingApp := &unstructured.Unstructured{}
 	existingApp.SetGroupVersionKind(argocdApplicationGvk)
-	if err := r.client.Get(ctx, client.ObjectKey{Name: appName, Namespace: inst.GetNamespace()}, existingApp); err != nil {
-		log.Info().Err(err).Msg("Application not found, waiting for DeploymentSubroutine to create it")
-		return subroutineslib.OK(), fmt.Errorf("application %s/%s not found", inst.GetNamespace(), appName)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: appName, Namespace: appNamespace}, existingApp); err != nil {
+		log.Info().Err(err).Str("namespace", appNamespace).Msg("Application not found, waiting for DeploymentSubroutine to create it")
+		return subroutineslib.OK(), fmt.Errorf("application %s/%s not found", appNamespace, appName)
 	}
 
 	currentRevision, _, _ := unstructured.NestedString(existingApp.Object, "spec", "source", "targetRevision")
@@ -272,7 +274,7 @@ func (r *ResourceSubroutine) updateArgoCDApplication(ctx context.Context, inst *
 	patchObj := &unstructured.Unstructured{}
 	patchObj.SetGroupVersionKind(argocdApplicationGvk)
 	patchObj.SetName(appName)
-	patchObj.SetNamespace(inst.GetNamespace())
+	patchObj.SetNamespace(appNamespace)
 	if err := unstructured.SetNestedField(patchObj.Object, targetRevision, "spec", "source", "targetRevision"); err != nil {
 		return subroutineslib.OK(), err
 	}
@@ -365,7 +367,8 @@ func firstNonEmpty(values ...string) string {
 }
 
 func (r *ResourceSubroutine) updateArgoCDApplicationHelmValues(ctx context.Context, inst *unstructured.Unstructured, log *logger.Logger) (subroutineslib.Result, error) {
-	appName, appNamespace := parseNamespacedName(getMetadataValue(inst, "for"), inst.GetName(), inst.GetNamespace())
+	defaultNamespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
+	appName, appNamespace := parseNamespacedName(getMetadataValue(inst, "for"), inst.GetName(), defaultNamespace)
 	updatePath := parsePath(getMetadataValue(inst, "path"), "image.tag")
 	pathStr := strings.Join(updatePath, ".")
 
@@ -497,7 +500,7 @@ func (r *ResourceSubroutine) updateHelmRelease(ctx context.Context, inst *unstru
 	}
 
 	name := trimPMSuffixes(inst.GetName())
-	namespace := inst.GetNamespace()
+	namespace := r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log)
 
 	// GET the existing HelmRelease so we can do a merge update instead of SSA,
 	// which would require a full valid spec (chart.spec.chart, chart.spec.sourceRef, etc.).
@@ -654,6 +657,46 @@ func (r *ResourceSubroutine) updateGitRepo(ctx context.Context, inst *unstructur
 		return subroutineslib.OK(), err
 	}
 	return subroutineslib.OK(), nil
+}
+
+// getAppNamespaceFromProfile returns the namespace where Application CRs are deployed.
+// If the profile sets a deploymentNamespace (infra or components section), use that.
+// Otherwise fall back to the Resource CR's own namespace.
+func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, resourceNamespace string, log *logger.Logger) string {
+	configMapNames := []string{"platform-mesh-profile", "platform-mesh-system-profile"}
+
+	for _, cmName := range configMapNames {
+		configMap := &corev1.ConfigMap{}
+		if err := r.clientRuntime.Get(ctx, types.NamespacedName{Name: cmName, Namespace: resourceNamespace}, configMap); err != nil {
+			continue
+		}
+
+		profileYAML, ok := configMap.Data["profile.yaml"]
+		if !ok {
+			continue
+		}
+
+		var profile map[string]interface{}
+		if err := yaml.Unmarshal([]byte(profileYAML), &profile); err != nil {
+			continue
+		}
+
+		if infra, ok := profile["infra"].(map[string]interface{}); ok {
+			if ns, ok := infra["deploymentNamespace"].(string); ok && ns != "" {
+				log.Debug().Str("appNamespace", ns).Str("source", "infra.deploymentNamespace").Msg("Resolved app namespace from profile")
+				return ns
+			}
+		}
+
+		if components, ok := profile["components"].(map[string]interface{}); ok {
+			if ns, ok := components["deploymentNamespace"].(string); ok && ns != "" {
+				log.Debug().Str("appNamespace", ns).Str("source", "components.deploymentNamespace").Msg("Resolved app namespace from profile")
+				return ns
+			}
+		}
+	}
+
+	return resourceNamespace
 }
 
 func (r *ResourceSubroutine) getDeploymentTechnologyFromProfile(ctx context.Context, namespace string, log *logger.Logger) (string, error) {

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -24,6 +24,8 @@ import (
 
 const requeueShort = 5 * time.Second
 
+var profileConfigMapNames = []string{"platform-mesh-profile", "platform-mesh-system-profile"}
+
 var ociRepoGvk = schema.GroupVersionKind{
 	Group:   "source.toolkit.fluxcd.io",
 	Version: "v1",
@@ -535,7 +537,7 @@ func (r *ResourceSubroutine) updateHelmRepository(ctx context.Context, inst *uns
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(helmRepoGvk)
 	obj.SetName(trimPMSuffixes(inst.GetName()))
-	obj.SetNamespace(inst.GetNamespace())
+	obj.SetNamespace(r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log))
 	_ = unstructured.SetNestedField(obj.Object, url, "spec", "url")
 	_ = unstructured.SetNestedField(obj.Object, "generic", "spec", "provider")
 	_ = unstructured.SetNestedField(obj.Object, "5m", "spec", "interval")
@@ -583,7 +585,7 @@ func (r *ResourceSubroutine) updateOciRepo(ctx context.Context, inst *unstructur
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(ociRepoGvk)
 	obj.SetName(trimPMSuffixes(inst.GetName()))
-	obj.SetNamespace(inst.GetNamespace())
+	obj.SetNamespace(r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log))
 
 	// Set desired fields
 	if err := unstructured.SetNestedField(obj.Object, version, "spec", "ref", "tag"); err != nil {
@@ -635,7 +637,7 @@ func (r *ResourceSubroutine) updateGitRepo(ctx context.Context, inst *unstructur
 
 	obj.SetGroupVersionKind(gitRepoGvk)
 	obj.SetName(trimPMSuffixes(inst.GetName()))
-	obj.SetNamespace(inst.GetNamespace())
+	obj.SetNamespace(r.getAppNamespaceFromProfile(ctx, inst.GetNamespace(), log))
 
 	// Set desired fields
 	if err := unstructured.SetNestedField(obj.Object, commit, "spec", "ref", "commit"); err != nil {
@@ -663,7 +665,7 @@ func (r *ResourceSubroutine) updateGitRepo(ctx context.Context, inst *unstructur
 // If the profile sets a deploymentNamespace (infra or components section), use that.
 // Otherwise fall back to the Resource CR's own namespace.
 func (r *ResourceSubroutine) getAppNamespaceFromProfile(ctx context.Context, resourceNamespace string, log *logger.Logger) string {
-	configMapNames := []string{"platform-mesh-profile", "platform-mesh-system-profile"}
+	configMapNames := profileConfigMapNames
 
 	for _, cmName := range configMapNames {
 		configMap := &corev1.ConfigMap{}
@@ -732,7 +734,7 @@ func (r *ResourceSubroutine) getDeploymentTechnologyFromProfile(ctx context.Cont
 }
 
 func (r *ResourceSubroutine) getDeploymentTechnologyFromConfigMapDirect(ctx context.Context, namespace string, log *logger.Logger) (string, error) {
-	configMapNames := []string{"platform-mesh-profile", "platform-mesh-system-profile"}
+	configMapNames := profileConfigMapNames
 
 	for _, cmName := range configMapNames {
 		configMap := &corev1.ConfigMap{}

--- a/pkg/subroutines/resource/subroutine_test.go
+++ b/pkg/subroutines/resource/subroutine_test.go
@@ -346,6 +346,7 @@ func (s *ResourceTestSuite) Test_updateGitRepo() {
 	s.subroutine = NewResourceSubroutine(clientMock, nil, nil)
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(errors.New("not found")).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 			gitRepo := obj.(*unstructured.Unstructured)
@@ -406,6 +407,7 @@ func (s *ResourceTestSuite) Test_updateGitRepo_CreateOrUpdateError() {
 	s.subroutine = NewResourceSubroutine(clientMock, nil, nil)
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(errors.New("not found")).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("client error"))
 
 	result, err := s.subroutine.Process(ctx, inst)
@@ -823,6 +825,7 @@ func (s *ResourceTestSuite) Test_updateOciRepo_CreateOrUpdateError() {
 	s.subroutine = NewResourceSubroutine(clientMock, nil, nil)
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(errors.New("not found")).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("client error"))
 
 	result, err := s.subroutine.Process(ctx, inst)

--- a/pkg/subroutines/resource/subroutine_test.go
+++ b/pkg/subroutines/resource/subroutine_test.go
@@ -1144,14 +1144,14 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_InfraDeploymentNames
 	}), mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			cm := obj.(*corev1.ConfigMap)
-			cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentNamespace: dxp-dev\n  deploymentTechnology: argocd\n"}
+			cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentNamespace: my-apps\n  deploymentTechnology: argocd\n"}
 			return nil
 		},
 	)
 
 	log := logger.LoadLoggerFromContext(ctx)
 	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
-	s.Equal("dxp-dev", ns)
+	s.Equal("my-apps", ns)
 }
 
 func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_ComponentsDeploymentNamespace() {
@@ -1164,14 +1164,14 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_ComponentsDeployment
 	}), mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			cm := obj.(*corev1.ConfigMap)
-			cm.Data = map[string]string{"profile.yaml": "components:\n  deploymentNamespace: dxp-int\n"}
+			cm.Data = map[string]string{"profile.yaml": "components:\n  deploymentNamespace: my-apps-int\n"}
 			return nil
 		},
 	)
 
 	log := logger.LoadLoggerFromContext(ctx)
 	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
-	s.Equal("dxp-int", ns)
+	s.Equal("my-apps-int", ns)
 }
 
 func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_Fallback() {
@@ -1245,7 +1245,7 @@ func (s *ResourceTestSuite) Test_updateArgoCDApplication_UsesDeploymentNamespace
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if key.Name == "platform-mesh-profile" || key.Name == "platform-mesh-system-profile" {
 				cm := obj.(*corev1.ConfigMap)
-				cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentNamespace: dxp-dev\n  deploymentTechnology: argocd\n"}
+				cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentNamespace: my-apps\n  deploymentTechnology: argocd\n"}
 				return nil
 			}
 			unstr := obj.(*unstructured.Unstructured)
@@ -1258,7 +1258,7 @@ func (s *ResourceTestSuite) Test_updateArgoCDApplication_UsesDeploymentNamespace
 	)
 	clientMock.EXPECT().Patch(mock.Anything, mock.MatchedBy(func(obj client.Object) bool {
 		unstr := obj.(*unstructured.Unstructured)
-		return unstr.GetNamespace() == "dxp-dev" && unstr.GetName() == "keycloak"
+		return unstr.GetNamespace() == "my-apps" && unstr.GetName() == "keycloak"
 	}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	result, err := sub.Process(ctx, inst)

--- a/pkg/subroutines/resource/subroutine_test.go
+++ b/pkg/subroutines/resource/subroutine_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/platform-mesh/golang-commons/logger"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines/mocks"
 	"github.com/stretchr/testify/mock"
@@ -278,6 +279,9 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag() {
 			clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 			clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 				func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); ok {
+						return errors.New("not found")
+					}
 					unstr := obj.(*unstructured.Unstructured)
 					unstr.SetName(key.Name)
 					unstr.SetNamespace(key.Namespace)
@@ -462,13 +466,16 @@ func (s *ResourceTestSuite) Test_updateHelmRepository() {
 	}), mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.ConfigMap); ok {
+				return errors.New("not found")
+			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
 			unstr.SetNamespace(key.Namespace)
 			unstr.Object["spec"] = map[string]interface{}{"chart": map[string]interface{}{"spec": map[string]interface{}{}}}
 			return nil
 		},
-	).Times(1)
+	)
 	clientMock.EXPECT().Update(mock.Anything, mock.MatchedBy(func(obj client.Object) bool {
 		unstr := obj.(*unstructured.Unstructured)
 		version, found, err := unstructured.NestedString(unstr.Object, "spec", "chart", "spec", "version")
@@ -552,13 +559,16 @@ func (s *ResourceTestSuite) Test_updateHelmRelease() {
 	}), mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.ConfigMap); ok {
+				return errors.New("not found")
+			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
 			unstr.SetNamespace(key.Namespace)
 			unstr.Object["spec"] = map[string]interface{}{"chart": map[string]interface{}{"spec": map[string]interface{}{}}}
 			return nil
 		},
-	).Times(1)
+	)
 	clientMock.EXPECT().Update(mock.Anything, mock.MatchedBy(func(obj client.Object) bool {
 		unstr := obj.(*unstructured.Unstructured)
 		version, found, err := unstructured.NestedString(unstr.Object, "spec", "chart", "spec", "version")
@@ -603,7 +613,7 @@ func (s *ResourceTestSuite) Test_updateHelmRelease_GetError() {
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
-	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("get error")).Times(1)
+	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("get error"))
 
 	result, err := subroutine.Process(ctx, inst)
 	s.NotNil(err)
@@ -645,13 +655,16 @@ func (s *ResourceTestSuite) Test_updateHelmRelease_UpdateError() {
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.ConfigMap); ok {
+				return errors.New("not found")
+			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
 			unstr.SetNamespace(key.Namespace)
 			unstr.Object["spec"] = map[string]interface{}{"chart": map[string]interface{}{"spec": map[string]interface{}{}}}
 			return nil
 		},
-	).Times(1)
+	)
 	clientMock.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("update error")).Times(1)
 
 	result, err := subroutine.Process(ctx, inst)
@@ -724,6 +737,9 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag_UpdateError() {
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.ConfigMap); ok {
+				return errors.New("not found")
+			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
 			unstr.SetNamespace(key.Namespace)
@@ -1113,4 +1129,136 @@ func (s *ResourceTestSuite) Test_SetRuntimeClient() {
 	sub := NewResourceSubroutine(s.clientMock, nil, nil)
 	sub.SetRuntimeClient(clientMock)
 	s.Equal(clientMock, sub.clientRuntime)
+}
+
+func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_InfraDeploymentNamespace() {
+	ctx := context.TODO()
+	clientMock := new(mocks.Client)
+	sub := NewResourceSubroutine(clientMock, nil, nil)
+
+	clientMock.EXPECT().Get(mock.Anything, mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "platform-mesh-profile" && key.Namespace == "platform-mesh-system"
+	}), mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cm := obj.(*corev1.ConfigMap)
+			cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentNamespace: dxp-dev\n  deploymentTechnology: argocd\n"}
+			return nil
+		},
+	)
+
+	log := logger.LoadLoggerFromContext(ctx)
+	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Equal("dxp-dev", ns)
+}
+
+func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_ComponentsDeploymentNamespace() {
+	ctx := context.TODO()
+	clientMock := new(mocks.Client)
+	sub := NewResourceSubroutine(clientMock, nil, nil)
+
+	clientMock.EXPECT().Get(mock.Anything, mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "platform-mesh-profile" && key.Namespace == "platform-mesh-system"
+	}), mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cm := obj.(*corev1.ConfigMap)
+			cm.Data = map[string]string{"profile.yaml": "components:\n  deploymentNamespace: dxp-int\n"}
+			return nil
+		},
+	)
+
+	log := logger.LoadLoggerFromContext(ctx)
+	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Equal("dxp-int", ns)
+}
+
+func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_Fallback() {
+	ctx := context.TODO()
+	clientMock := new(mocks.Client)
+	sub := NewResourceSubroutine(clientMock, nil, nil)
+
+	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("not found"))
+
+	log := logger.LoadLoggerFromContext(ctx)
+	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Equal("platform-mesh-system", ns)
+}
+
+func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_NoDeploymentNamespace() {
+	ctx := context.TODO()
+	clientMock := new(mocks.Client)
+	sub := NewResourceSubroutine(clientMock, nil, nil)
+
+	clientMock.EXPECT().Get(mock.Anything, mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "platform-mesh-profile" && key.Namespace == "platform-mesh-system"
+	}), mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cm := obj.(*corev1.ConfigMap)
+			cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentTechnology: argocd\n"}
+			return nil
+		},
+	)
+	clientMock.EXPECT().Get(mock.Anything, mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "platform-mesh-system-profile" && key.Namespace == "platform-mesh-system"
+	}), mock.Anything, mock.Anything).Return(errors.New("not found"))
+
+	log := logger.LoadLoggerFromContext(ctx)
+	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Equal("platform-mesh-system", ns)
+}
+
+func (s *ResourceTestSuite) Test_updateArgoCDApplication_UsesDeploymentNamespace() {
+	ctx := context.TODO()
+
+	inst := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "delivery.ocm.software/v1alpha1",
+			"kind":       "Resource",
+			"metadata": map[string]interface{}{
+				"name":      "keycloak-chart",
+				"namespace": "platform-mesh-system",
+				"annotations": map[string]interface{}{
+					"artifact": "chart",
+					"repo":     "helm",
+				},
+			},
+			"status": map[string]interface{}{
+				"resource": map[string]interface{}{
+					"version": "25.2.3",
+					"access": map[string]interface{}{
+						"type":           "helmChart",
+						"helmRepository": "https://charts.bitnami.com/bitnami",
+					},
+				},
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+
+	clientMock := new(mocks.Client)
+	sub := NewResourceSubroutine(clientMock, nil, nil)
+
+	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("no CRD")).Maybe()
+	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if key.Name == "platform-mesh-profile" || key.Name == "platform-mesh-system-profile" {
+				cm := obj.(*corev1.ConfigMap)
+				cm.Data = map[string]string{"profile.yaml": "infra:\n  deploymentNamespace: dxp-dev\n  deploymentTechnology: argocd\n"}
+				return nil
+			}
+			unstr := obj.(*unstructured.Unstructured)
+			unstr.SetName(key.Name)
+			unstr.SetNamespace(key.Namespace)
+			_ = unstructured.SetNestedField(unstr.Object, "https://old-repo.com", "spec", "source", "repoURL")
+			_ = unstructured.SetNestedField(unstr.Object, "1.0.0", "spec", "source", "targetRevision")
+			return nil
+		},
+	)
+	clientMock.EXPECT().Patch(mock.Anything, mock.MatchedBy(func(obj client.Object) bool {
+		unstr := obj.(*unstructured.Unstructured)
+		return unstr.GetNamespace() == "dxp-dev" && unstr.GetName() == "keycloak"
+	}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	result, err := sub.Process(ctx, inst)
+	s.Nil(err)
+	s.NotNil(result)
 }

--- a/pkg/subroutines/resource/subroutine_test.go
+++ b/pkg/subroutines/resource/subroutine_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -280,7 +282,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag() {
 			clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 				func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if _, ok := obj.(*corev1.ConfigMap); ok {
-						return errors.New("not found")
+						return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")
 					}
 					unstr := obj.(*unstructured.Unstructured)
 					unstr.SetName(key.Name)
@@ -346,7 +348,7 @@ func (s *ResourceTestSuite) Test_updateGitRepo() {
 	s.subroutine = NewResourceSubroutine(clientMock, nil, nil)
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(errors.New("not found")).Maybe()
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 			gitRepo := obj.(*unstructured.Unstructured)
@@ -407,7 +409,7 @@ func (s *ResourceTestSuite) Test_updateGitRepo_CreateOrUpdateError() {
 	s.subroutine = NewResourceSubroutine(clientMock, nil, nil)
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(errors.New("not found")).Maybe()
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("client error"))
 
 	result, err := s.subroutine.Process(ctx, inst)
@@ -469,7 +471,7 @@ func (s *ResourceTestSuite) Test_updateHelmRepository() {
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, ok := obj.(*corev1.ConfigMap); ok {
-				return errors.New("not found")
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")
 			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
@@ -562,7 +564,7 @@ func (s *ResourceTestSuite) Test_updateHelmRelease() {
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, ok := obj.(*corev1.ConfigMap); ok {
-				return errors.New("not found")
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")
 			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
@@ -658,7 +660,7 @@ func (s *ResourceTestSuite) Test_updateHelmRelease_UpdateError() {
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, ok := obj.(*corev1.ConfigMap); ok {
-				return errors.New("not found")
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")
 			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
@@ -740,7 +742,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag_UpdateError() {
 	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, ok := obj.(*corev1.ConfigMap); ok {
-				return errors.New("not found")
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")
 			}
 			unstr := obj.(*unstructured.Unstructured)
 			unstr.SetName(key.Name)
@@ -825,7 +827,7 @@ func (s *ResourceTestSuite) Test_updateOciRepo_CreateOrUpdateError() {
 	s.subroutine = NewResourceSubroutine(clientMock, nil, nil)
 
 	clientMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(errors.New("not found")).Maybe()
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.ConfigMap"), mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "")).Maybe()
 	clientMock.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("client error"))
 
 	result, err := s.subroutine.Process(ctx, inst)
@@ -1150,7 +1152,8 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_InfraDeploymentNames
 	)
 
 	log := logger.LoadLoggerFromContext(ctx)
-	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	ns, err := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Require().NoError(err)
 	s.Equal("my-apps", ns)
 }
 
@@ -1170,7 +1173,8 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_ComponentsDeployment
 	)
 
 	log := logger.LoadLoggerFromContext(ctx)
-	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	ns, err := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Require().NoError(err)
 	s.Equal("my-apps-int", ns)
 }
 
@@ -1179,10 +1183,11 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_Fallback() {
 	clientMock := new(mocks.Client)
 	sub := NewResourceSubroutine(clientMock, nil, nil)
 
-	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("not found"))
+	clientMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "platform-mesh-profile"))
 
 	log := logger.LoadLoggerFromContext(ctx)
-	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	ns, err := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Require().NoError(err)
 	s.Equal("platform-mesh-system", ns)
 }
 
@@ -1202,10 +1207,11 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_NoDeploymentNamespac
 	)
 	clientMock.EXPECT().Get(mock.Anything, mock.MatchedBy(func(key client.ObjectKey) bool {
 		return key.Name == "platform-mesh-system-profile" && key.Namespace == "platform-mesh-system"
-	}), mock.Anything, mock.Anything).Return(errors.New("not found"))
+	}), mock.Anything, mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "platform-mesh-system-profile"))
 
 	log := logger.LoadLoggerFromContext(ctx)
-	ns := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	ns, err := sub.getAppNamespaceFromProfile(ctx, "platform-mesh-system", log)
+	s.Require().NoError(err)
 	s.Equal("platform-mesh-system", ns)
 }
 

--- a/pkg/subroutines/subroutine_helpers.go
+++ b/pkg/subroutines/subroutine_helpers.go
@@ -804,9 +804,9 @@ func GetDeploymentTechnologyFromProfile(ctx context.Context, cl client.Client, i
 		return "", fmt.Errorf("failed to get profile ConfigMap %s/%s: %w", configMapNamespace, configMapName, err)
 	}
 
-	profileYAML, ok := configMap.Data["profile.yaml"]
+	profileYAML, ok := configMap.Data[profileConfigMapKey]
 	if !ok {
-		return "", fmt.Errorf("profile ConfigMap %s/%s does not contain key 'profile.yaml'", configMapNamespace, configMapName)
+		return "", fmt.Errorf("profile ConfigMap %s/%s does not contain key %s", configMapNamespace, configMapName, profileConfigMapKey)
 	}
 
 	var profile map[string]interface{}


### PR DESCRIPTION
## Summary
- ResourceSubroutine now reads `deploymentNamespace` from profile to find Application CRs
- Affects both `updateArgoCDApplication` (chart repoURL/targetRevision) and `updateArgoCDApplicationHelmValues` (image.tag)
- Adds `getAppNamespaceFromProfile` helper reused by both methods

## Problem
When `deploymentNamespace` is set in the profile (e.g. `release-namespace`), DeploymentSubroutine creates Application CRs in that namespace. But ResourceSubroutine still looked for apps in `inst.GetNamespace()` (the Resource CR's namespace, `platform-mesh-system`). Result: apps in `dxp-dev` kept `repoURL: PLACEHOLDER_TO_BE_SET_BY_RESOURCE_SUBROUTINE` forever.

## How it works
1. `getAppNamespaceFromProfile` reads the profile ConfigMap from the Resource CR's namespace
2. Checks `infra.deploymentNamespace`, then `components.deploymentNamespace`
3. Falls back to the Resource CR's namespace if neither is set (backwards compatible)
4. Used in both ArgoCD update methods for Get and Patch operations

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/subroutines/resource/...` passes
- [ ] Deploy and verify apps in `dxp-dev` get resolved repoURL/targetRevision