### PR TITLE
fix(appproject): align sourceNamespaces with deployment namespace

### DIFF
--- a/gotemplates/infra/infra/appproject.yaml
+++ b/gotemplates/infra/infra/appproject.yaml
@@ -18,9 +18,10 @@ spec:
     - namespace: etcd-druid-system
       server: {{ .destinationServer | default "https://kubernetes.default.svc" }}
   sourceNamespaces:
-    - {{ .releaseNamespace }}
-{{- if and .helmReleaseNamespace (ne .helmReleaseNamespace .releaseNamespace) }}
+{{- if .helmReleaseNamespace }}
     - {{ .helmReleaseNamespace }}
+{{- else }}
+    - {{ .releaseNamespace }}
 {{- end }}
   clusterResourceWhitelist:
     - group: '*'


### PR DESCRIPTION
## Summary
- AppProject `sourceNamespaces` previously listed both `releaseNamespace` (platform-mesh-system) and `helmReleaseNamespace` (dxp-<env>)
- Application CRs are now exclusively created in `helmReleaseNamespace` via `getAppNamespaceFromProfile`
- Remove stale `releaseNamespace` from `sourceNamespaces` — only include `helmReleaseNamespace` when set
- Falls back to `releaseNamespace` for single-cluster deployments where `helmReleaseNamespace` is unset

## Context
After merging #739, ArgoCD apps live in `dxp-dev` but the AppProject still listed `platform-mesh-system` as a source namespace. This caused SharedResourceWarnings due to old orphaned apps in that namespace still being watched.

## Test plan
- [x] `go test ./pkg/subroutines/...` passes
- [ ] After deploy: verify AppProject `sourceNamespaces` contains only `dxp-dev`
- [ ] Verify SharedResourceWarnings resolve once old apps are cleaned up