### PR TITLE
fix(templates): use releaseNamespace for OCM Resource CRs on runtime cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,11 +378,11 @@ gotemplates/
 
 **Infra templates** (`gotemplates/infra/infra/`) receive the profile's `infra` section merged with:
 
-| Variable | Source |
-|----------|--------|
-| `releaseNamespace` | PlatformMesh instance namespace |
-| `deploymentNamespace` | Profile `infra.deploymentNamespace` (falls back to instance namespace) |
-| `helmReleaseNamespace` | Same as `deploymentNamespace` |
+| Variable | Source | Target cluster |
+|----------|--------|----------------|
+| `releaseNamespace` | PlatformMesh instance namespace (e.g., `platform-mesh-system`) | Runtime — namespace where OCM Resource CRs are created |
+| `deploymentNamespace` | Profile `infra.deploymentNamespace` (falls back to instance namespace) | Infra |
+| `helmReleaseNamespace` | Same as `deploymentNamespace` | Infra — namespace where ArgoCD/Flux apps are created |
 | `deploymentTechnology` | Profile or templateVars (`fluxcd` / `argocd`) |
 | `kubeConfigEnabled` | `true` if `--remote-runtime-kubeconfig` is set |
 | `kubeConfigSecretName` | `--remote-runtime-infra-secret-name` |
@@ -426,7 +426,7 @@ components:
 
 Result: `metadata.namespace: argocd-apps` (where the CR lives), `spec.destination.namespace: platform-mesh-system` (where workloads deploy). If omitted, both default to the PlatformMesh CR namespace.
 
-**Runtime templates** (`gotemplates/infra/runtime/` and `gotemplates/components/runtime/`) additionally receive:
+**Runtime templates** (`gotemplates/infra/runtime/` and `gotemplates/components/runtime/`) are applied to the **runtime cluster**. Use `releaseNamespace` for `metadata.namespace` of resources created here (not `helmReleaseNamespace`, which targets the infra cluster). Additionally receive:
 
 | Variable | Source |
 |----------|--------|

--- a/gotemplates/infra/runtime/cert-manager/resource-cainjector.yaml
+++ b/gotemplates/infra/runtime/cert-manager/resource-cainjector.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     path: cainjector.image.tag
   name: {{ .certManager.name }}-cainjector-image
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/cert-manager/resource-controller.yaml
+++ b/gotemplates/infra/runtime/cert-manager/resource-controller.yaml
@@ -7,7 +7,7 @@ metadata:
     repo: oci
     for: cert-manager
   name: {{ .certManager.name }}-controller-image
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/cert-manager/resource-webhook.yaml
+++ b/gotemplates/infra/runtime/cert-manager/resource-webhook.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     path: webhook.image.tag
   name: {{ .certManager.name }}-webhook-image
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/cert-manager/resource.yaml
+++ b/gotemplates/infra/runtime/cert-manager/resource.yaml
@@ -6,7 +6,7 @@ metadata:
     artifact: chart
     repo: oci
   name: {{ .certManager.name }}
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/gateway-api/resource.yaml
+++ b/gotemplates/infra/runtime/gateway-api/resource.yaml
@@ -6,7 +6,7 @@ metadata:
     artifact: chart
     repo: git
   name: {{ .gatewayApi.name }}
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/opentelemetry-operator/resource.yaml
+++ b/gotemplates/infra/runtime/opentelemetry-operator/resource.yaml
@@ -6,7 +6,7 @@ metadata:
     artifact: chart
     repo: oci
   name: {{ .opentelemetryOperator.name }}
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/prometheus-operator-crds/resource.yaml
+++ b/gotemplates/infra/runtime/prometheus-operator-crds/resource.yaml
@@ -6,7 +6,7 @@ metadata:
     artifact: chart
     repo: oci
   name: {{ .prometheusOperatorCRDs.name }}
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/traefik/resource-crds.yaml
+++ b/gotemplates/infra/runtime/traefik/resource-crds.yaml
@@ -6,7 +6,7 @@ metadata:
     artifact: chart
     repo: oci
   name: {{ .traefikCRDs.name }}
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}

--- a/gotemplates/infra/runtime/traefik/resource.yaml
+++ b/gotemplates/infra/runtime/traefik/resource.yaml
@@ -6,7 +6,7 @@ metadata:
     artifact: chart
     repo: oci
   name: {{ .traefik.name }}
-  namespace: {{ .helmReleaseNamespace }}
+  namespace: {{ .releaseNamespace }}
 spec:
   componentRef:
     name: {{ .ocm.component.name }}


### PR DESCRIPTION
## Summary

- OCM Resource CRs are routed to the runtime cluster via `clientRuntime`
- Templates used `{{ .helmReleaseNamespace }}` (= deployment namespace) for `metadata.namespace`, but that namespace only exists on the infra cluster
- Changed all 9 runtime OCM Resource templates to use `{{ .releaseNamespace }}` (= `platform-mesh-system`), matching the existing `etcd-druid` pattern

## Problem

After moving the operator to the deployment namespace on infra (platform-mesh-stacks PR #107), the operator fails with:
```
Failed to apply rendered manifest: namespaces "<deploymentNamespace>" not found
```

## Test plan

- [x] `go test ./pkg/subroutines/... -run TestDeployment` passes
- [x] No `helmReleaseNamespace` remains in `gotemplates/infra/runtime/`
- [ ] After deploy: operator logs stop showing namespace not found errors