### PR TITLE
Consider scheme in registry addr

### DIFF
--- a/internal/ociref/ociref.go
+++ b/internal/ociref/ociref.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ociref
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/platform-mesh/platform-mesh-operator/pkg/ocm"
+)
+
+// StripScheme removes the scheme (e.g. "oci://", "http://") from an image reference,
+// returning the bare host/path portion.
+func StripScheme(ref string) string {
+	if i := strings.Index(ref, "://"); i >= 0 {
+		return ref[i+3:]
+	}
+	return ref
+}
+
+// SplitRegistry splits an OCM/OCI registry root (e.g. "ghcr.io/platform-mesh") into the
+// host (baseURL) and the remaining sub-path for a delivery.ocm.software Repository.
+func SplitRegistry(registry string) (baseURL, subPath string) {
+	p, _ := url.Parse(registry)
+
+	// got a URL like "http://host/path:tag"
+	if p.Scheme != "" {
+		subPath = strings.TrimLeft(p.Path, "/")
+		baseURL = p.Scheme + "://" + p.Host
+	} else {
+		// without a scheme, Go cannot split host and path,
+		// so we must do it ourselves
+		baseURL, subPath, _ = strings.Cut(p.Path, "/")
+	}
+
+	return
+}
+
+// NormalizeOCIURL turns an OCM-resolved imageReference (and version) into a clean
+// oci://host/repository URL suitable for a Flux OCIRepository spec.url. Plain-HTTP
+// registries store http:// in the imageReference; we normalise to oci:// regardless
+// because Flux always uses that scheme (plain-HTTP is enabled via spec.insecure).
+func NormalizeOCIURL(imageRef, version string) (string, error) {
+	imageRef = StripScheme(imageRef)
+	url := strings.TrimSuffix("oci://"+imageRef, ":"+version)
+	spec, err := ocm.ParseRef(url)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s://%s/%s", spec.Scheme, spec.Host, spec.Repository), nil
+}
+
+// ExtractRepoURL strips the scheme and the final path component (image name) from an
+// OCI image reference, returning the parent repository path (host/repo-prefix).
+func ExtractRepoURL(imageRef string) (string, error) {
+	imageRef = StripScheme(imageRef)
+	baseURL := strings.Split(imageRef, ":")[0]
+	lastSlash := strings.LastIndex(baseURL, "/")
+	if lastSlash == -1 {
+		return "", fmt.Errorf("invalid imageReference format: %s", imageRef)
+	}
+	return baseURL[:lastSlash], nil
+}

--- a/internal/ociref/ociref.go
+++ b/internal/ociref/ociref.go
@@ -18,7 +18,6 @@ package ociref
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/platform-mesh/platform-mesh-operator/pkg/ocm"
@@ -36,18 +35,13 @@ func StripScheme(ref string) string {
 // SplitRegistry splits an OCM/OCI registry root (e.g. "ghcr.io/platform-mesh") into the
 // host (baseURL) and the remaining sub-path for a delivery.ocm.software Repository.
 func SplitRegistry(registry string) (baseURL, subPath string) {
-	p, _ := url.Parse(registry)
+	registryWithoutScheme := StripScheme(registry)
+	scheme, _ := strings.CutSuffix(registry, registryWithoutScheme)
+	baseURL, subPath, _ = strings.Cut(registryWithoutScheme, "/")
 
-	// got a URL like "http://host/path:tag"
-	if p.Scheme != "" {
-		subPath = strings.TrimLeft(p.Path, "/")
-		baseURL = p.Scheme + "://" + p.Host
-	} else {
-		// without a scheme, Go cannot split host and path,
-		// so we must do it ourselves
-		baseURL, subPath, _ = strings.Cut(p.Path, "/")
+	if scheme != "" {
+		baseURL = scheme + baseURL
 	}
-
 	return
 }
 

--- a/internal/ociref/ociref_test.go
+++ b/internal/ociref/ociref_test.go
@@ -1,0 +1,84 @@
+package ociref_test
+
+import (
+	"testing"
+
+	"github.com/platform-mesh/platform-mesh-operator/internal/ociref"
+)
+
+func TestStripScheme(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"oci://ghcr.io/org/repo", "ghcr.io/org/repo"},
+		{"http://kind-registry:5000/org/repo", "kind-registry:5000/org/repo"},
+		{"ghcr.io/org/repo", "ghcr.io/org/repo"},
+		{"http://", ""},
+	}
+	for _, tc := range cases {
+		if got := ociref.StripScheme(tc.input); got != tc.want {
+			t.Errorf("StripScheme(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestSplitRegistry(t *testing.T) {
+	cases := []struct{ input, wantBase, wantSub string }{
+		{"ghcr.io/platform-mesh", "ghcr.io", "platform-mesh"},
+		{"ghcr.io/platform-mesh/provider-quickstart/charts", "ghcr.io", "platform-mesh/provider-quickstart/charts"},
+		{"ghcr.io", "ghcr.io", ""},
+		{"http://kind-registry:5000/ghcr.io/platform-mesh/provider-quickstart/wildwest-operator", "http://kind-registry:5000", "ghcr.io/platform-mesh/provider-quickstart/wildwest-operator"},
+		{"http://", "http://", ""},
+		{"http:///", "http://", ""},
+	}
+	for _, tc := range cases {
+		base, sub := ociref.SplitRegistry(tc.input)
+		if base != tc.wantBase || sub != tc.wantSub {
+			t.Errorf("SplitRegistry(%q) = (%q, %q), want (%q, %q)", tc.input, base, sub, tc.wantBase, tc.wantSub)
+		}
+	}
+}
+
+func TestNormalizeOCIURL(t *testing.T) {
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cases := []struct{ name, imageRef, version, want string }{
+		{"tag form", "oci://ghcr.io/platform-mesh/charts/wildwest:1.2.3", "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
+		{"no scheme", "ghcr.io/platform-mesh/charts/wildwest:1.2.3", "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
+		{"digest form", "oci://ghcr.io/platform-mesh/charts/wildwest@" + digest, "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
+		{"http scheme with digest", "http://kind-registry:5000/org/chart:1.2.3@" + digest, "1.2.3", "oci://kind-registry:5000/org/chart"},
+	}
+	for _, tc := range cases {
+		got, err := ociref.NormalizeOCIURL(tc.imageRef, tc.version)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: NormalizeOCIURL(%q, %q) = %q, want %q", tc.name, tc.imageRef, tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestExtractRepoURL(t *testing.T) {
+	cases := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"oci://registry.example.com/charts/mychart:1.0.0@sha256:abc", "registry.example.com/charts", false},
+		{"registry.example.com/org/charts/app:v2.0", "registry.example.com/org/charts", false},
+		{"noslash", "", true},
+	}
+	for _, tc := range cases {
+		got, err := ociref.ExtractRepoURL(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ExtractRepoURL(%q) expected error, got %q", tc.input, got)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("ExtractRepoURL(%q) error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("ExtractRepoURL(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		}
+	}
+}

--- a/pkg/subroutines/providers/deploy.go
+++ b/pkg/subroutines/providers/deploy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -100,15 +101,19 @@ func ocmDeploymentName(ocm *providersv1alpha1.OCMComponentSpec) string {
 // splitRegistry splits an OCM/OCI registry root (e.g. "ghcr.io/platform-mesh") into the
 // host (baseUrl) and the remaining sub-path for a delivery.ocm.software Repository.
 func splitRegistry(registry string) (baseURL, subPath string) {
-	const schemeSeparator = "://"
-	schemeIdx := strings.Index(registry, "://")
-	if schemeIdx >= 0 {
-		registryWithoutScheme := registry[schemeIdx+len(schemeSeparator):]
-		host, path, _ := strings.Cut(registryWithoutScheme, "/")
-		return registry[:schemeIdx+len(schemeSeparator)] + host, path
+	p, _ := url.Parse(registry)
+
+	// got a URL like "http://host/path:tag"
+	if p.Scheme != "" {
+		subPath = strings.TrimLeft(p.Path, "/")
+		baseURL = p.Scheme + "://" + p.Host
+	} else {
+		// without a scheme, Go cannot split host and path,
+		// so we must do it ourselves
+		baseURL, subPath, _ = strings.Cut(p.Path, "/")
 	}
-	baseURL, subPath, _ = strings.Cut(registry, "/")
-	return baseURL, subPath
+
+	return
 }
 
 // fluxSourceGVK returns the Flux source object kind for a component's source type.

--- a/pkg/subroutines/providers/deploy.go
+++ b/pkg/subroutines/providers/deploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -37,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	providersv1alpha1 "github.com/platform-mesh/platform-mesh-operator/api/providers/v1alpha1"
-	"github.com/platform-mesh/platform-mesh-operator/pkg/ocm"
+	"github.com/platform-mesh/platform-mesh-operator/internal/ociref"
 )
 
 const (
@@ -96,24 +95,6 @@ func ocmDeploymentName(ocm *providersv1alpha1.OCMComponentSpec) string {
 		return ocm.ReferencePath[n-1].Name
 	}
 	return chartResourceName(ocm.Component)
-}
-
-// splitRegistry splits an OCM/OCI registry root (e.g. "ghcr.io/platform-mesh") into the
-// host (baseUrl) and the remaining sub-path for a delivery.ocm.software Repository.
-func splitRegistry(registry string) (baseURL, subPath string) {
-	p, _ := url.Parse(registry)
-
-	// got a URL like "http://host/path:tag"
-	if p.Scheme != "" {
-		subPath = strings.TrimLeft(p.Path, "/")
-		baseURL = p.Scheme + "://" + p.Host
-	} else {
-		// without a scheme, Go cannot split host and path,
-		// so we must do it ourselves
-		baseURL, subPath, _ = strings.Cut(p.Path, "/")
-	}
-
-	return
 }
 
 // fluxSourceGVK returns the Flux source object kind for a component's source type.
@@ -343,24 +324,6 @@ func parseOCMValues(ocm *providersv1alpha1.OCMComponentSpec) (map[string]interfa
 	return values, nil
 }
 
-// ocmResolvedOCIURL turns an OCM-resolved imageReference (and version) into a clean
-// oci://host/repository URL suitable for a Flux OCIRepository spec.url. Mirrors the
-// resolution done by the PlatformMesh ResourceSubroutine.
-// Plain-HTTP registries store http:// in the imageReference; we normalise to oci://
-// regardless because Flux always uses that scheme (plain-HTTP is enabled via spec.insecure).
-func ocmResolvedOCIURL(imageRef, version string) (string, error) {
-	if i := strings.Index(imageRef, "://"); i >= 0 {
-		imageRef = imageRef[i+3:]
-	}
-	url := "oci://" + imageRef
-	url = strings.TrimSuffix(url, ":"+version)
-	spec, err := ocm.ParseRef(url)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s://%s/%s", spec.Scheme, spec.Host, spec.Repository), nil
-}
-
 // ocmConfigRepositoryRef returns the inline ocmConfig entry that points OCM objects at
 // the generated Repository.
 func ocmConfigRepositoryRef(name, namespace string) []interface{} {
@@ -397,7 +360,7 @@ func (r *DeploySubroutine) deployOCMComponent(ctx context.Context, namespace, na
 	}
 
 	// 1. Repository — the OCI registry holding the component.
-	baseURL, subPath := splitRegistry(ocmSpec.Registry)
+	baseURL, subPath := ociref.SplitRegistry(ocmSpec.Registry)
 	repository := &unstructured.Unstructured{}
 	repository.SetGroupVersionKind(deployOCMRepositoryGVK)
 	repository.SetName(name)
@@ -494,7 +457,7 @@ func (r *DeploySubroutine) deployOCMComponent(ctx context.Context, namespace, na
 		return subroutines.StopWithRequeue(deployRequeueDuration, fmt.Sprintf("waiting for OCM Resource %s status", name)), nil
 	}
 
-	ociURL, err := ocmResolvedOCIURL(imageRef, version)
+	ociURL, err := ociref.NormalizeOCIURL(imageRef, version)
 	if err != nil {
 		return subroutines.OK(), gcerrors.Wrap(err, "failed to parse resolved imageReference for %s", name)
 	}

--- a/pkg/subroutines/providers/deploy.go
+++ b/pkg/subroutines/providers/deploy.go
@@ -100,6 +100,13 @@ func ocmDeploymentName(ocm *providersv1alpha1.OCMComponentSpec) string {
 // splitRegistry splits an OCM/OCI registry root (e.g. "ghcr.io/platform-mesh") into the
 // host (baseUrl) and the remaining sub-path for a delivery.ocm.software Repository.
 func splitRegistry(registry string) (baseURL, subPath string) {
+	const schemeSeparator = "://"
+	schemeIdx := strings.Index(registry, "://")
+	if schemeIdx >= 0 {
+		registryWithoutScheme := registry[schemeIdx+len(schemeSeparator):]
+		host, path, _ := strings.Cut(registryWithoutScheme, "/")
+		return registry[:schemeIdx+len(schemeSeparator)] + host, path
+	}
 	baseURL, subPath, _ = strings.Cut(registry, "/")
 	return baseURL, subPath
 }
@@ -334,8 +341,13 @@ func parseOCMValues(ocm *providersv1alpha1.OCMComponentSpec) (map[string]interfa
 // ocmResolvedOCIURL turns an OCM-resolved imageReference (and version) into a clean
 // oci://host/repository URL suitable for a Flux OCIRepository spec.url. Mirrors the
 // resolution done by the PlatformMesh ResourceSubroutine.
+// Plain-HTTP registries store http:// in the imageReference; we normalise to oci://
+// regardless because Flux always uses that scheme (plain-HTTP is enabled via spec.insecure).
 func ocmResolvedOCIURL(imageRef, version string) (string, error) {
-	url := "oci://" + strings.TrimPrefix(imageRef, "oci://")
+	if i := strings.Index(imageRef, "://"); i >= 0 {
+		imageRef = imageRef[i+3:]
+	}
+	url := "oci://" + imageRef
 	url = strings.TrimSuffix(url, ":"+version)
 	spec, err := ocm.ParseRef(url)
 	if err != nil {
@@ -487,7 +499,10 @@ func (r *DeploySubroutine) deployOCMComponent(ctx context.Context, namespace, na
 		return subroutines.OK(), gcerrors.Wrap(err, "failed to unmarshal values for %s", name)
 	}
 
-	return r.reconcileResolvedOCIChart(ctx, namespace, name, ociURL, version, ocmSpec.Insecure, values, runtimeKubeconfigSecretName)
+	// Treat the resolved artifact as insecure if the user set insecure: true OR if the
+	// OCM controller stored an http:// imageReference (plain-HTTP registry).
+	insecure := ocmSpec.Insecure || strings.HasPrefix(imageRef, "http://")
+	return r.reconcileResolvedOCIChart(ctx, namespace, name, ociURL, version, insecure, values, runtimeKubeconfigSecretName)
 }
 
 // deployFluxHelmRepo deploys a chart from a classic HTTP(S) Helm repository via a

--- a/pkg/subroutines/providers/deploy_test.go
+++ b/pkg/subroutines/providers/deploy_test.go
@@ -630,20 +630,6 @@ func (s *DeployTestSuite) TestFinalize_HelmRepo_DeletesHelmRepository() {
 
 // --- ocm (OCM descriptor resolution) tests ---
 
-func (s *DeployTestSuite) TestOCMResolvedOCIURL() {
-	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	cases := []struct{ name, imageRef, version, want string }{
-		{"tag form", "oci://ghcr.io/platform-mesh/charts/wildwest:1.2.3", "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
-		{"no scheme", "ghcr.io/platform-mesh/charts/wildwest:1.2.3", "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
-		{"digest form", "oci://ghcr.io/platform-mesh/charts/wildwest@" + digest, "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
-		{"http scheme with digest", "http://kind-registry:5000/org/chart:1.2.3@" + digest, "1.2.3", "oci://kind-registry:5000/org/chart"},
-	}
-	for _, tc := range cases {
-		got, err := ocmResolvedOCIURL(tc.imageRef, tc.version)
-		s.Require().NoError(err, tc.name)
-		s.Assert().Equal(tc.want, got, tc.name)
-	}
-}
 
 func (s *DeployTestSuite) TestOCMDeploymentName() {
 	s.Equal("explicit", ocmDeploymentName(&providersv1alpha1.OCMComponentSpec{
@@ -661,26 +647,6 @@ func (s *DeployTestSuite) TestOCMDeploymentName() {
 	}))
 }
 
-func (s *DeployTestSuite) TestSplitRegistry() {
-	base, sub := splitRegistry("ghcr.io/platform-mesh")
-	s.Equal("ghcr.io", base)
-	s.Equal("platform-mesh", sub)
-	base, sub = splitRegistry("ghcr.io/platform-mesh/provider-quickstart/charts")
-	s.Equal("ghcr.io", base)
-	s.Equal("platform-mesh/provider-quickstart/charts", sub)
-	base, sub = splitRegistry("ghcr.io")
-	s.Equal("ghcr.io", base)
-	s.Equal("", sub)
-	base, sub = splitRegistry("http://kind-registry:5000/ghcr.io/platform-mesh/provider-quickstart/wildwest-operator")
-	s.Equal("http://kind-registry:5000", base)
-	s.Equal("ghcr.io/platform-mesh/provider-quickstart/wildwest-operator", sub)
-	base, sub = splitRegistry("http://")
-	s.Equal("http://", base)
-	s.Equal("", sub)
-	base, sub = splitRegistry("http:///")
-	s.Equal("http://", base)
-	s.Equal("", sub)
-}
 
 // newManagedProviderOCM returns a ManagedProvider with a single self-contained ocm
 // RuntimeDeployment; the deployment name is explicit ("wildwest-controller") and the

--- a/pkg/subroutines/providers/deploy_test.go
+++ b/pkg/subroutines/providers/deploy_test.go
@@ -636,6 +636,7 @@ func (s *DeployTestSuite) TestOCMResolvedOCIURL() {
 		{"tag form", "oci://ghcr.io/platform-mesh/charts/wildwest:1.2.3", "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
 		{"no scheme", "ghcr.io/platform-mesh/charts/wildwest:1.2.3", "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
 		{"digest form", "oci://ghcr.io/platform-mesh/charts/wildwest@" + digest, "1.2.3", "oci://ghcr.io/platform-mesh/charts/wildwest"},
+		{"http scheme with digest", "http://kind-registry:5000/org/chart:1.2.3@" + digest, "1.2.3", "oci://kind-registry:5000/org/chart"},
 	}
 	for _, tc := range cases {
 		got, err := ocmResolvedOCIURL(tc.imageRef, tc.version)
@@ -669,6 +670,15 @@ func (s *DeployTestSuite) TestSplitRegistry() {
 	s.Equal("platform-mesh/provider-quickstart/charts", sub)
 	base, sub = splitRegistry("ghcr.io")
 	s.Equal("ghcr.io", base)
+	s.Equal("", sub)
+	base, sub = splitRegistry("http://kind-registry:5000/ghcr.io/platform-mesh/provider-quickstart/wildwest-operator")
+	s.Equal("http://kind-registry:5000", base)
+	s.Equal("ghcr.io/platform-mesh/provider-quickstart/wildwest-operator", sub)
+	base, sub = splitRegistry("http://")
+	s.Equal("http://", base)
+	s.Equal("", sub)
+	base, sub = splitRegistry("http:///")
+	s.Equal("http://", base)
 	s.Equal("", sub)
 }
 

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -423,7 +423,9 @@ func (r *ResourceSubroutine) resolveArgoCDSource(inst *unstructured.Unstructured
 }
 
 func extractOCIRepoURL(imageRef string) (string, error) {
-	imageRef = strings.TrimPrefix(imageRef, "oci://")
+	if i := strings.Index(imageRef, "://"); i >= 0 {
+		imageRef = imageRef[i+3:]
+	}
 	baseURL := strings.Split(imageRef, ":")[0]
 	lastSlash := strings.LastIndex(baseURL, "/")
 	if lastSlash == -1 {
@@ -661,8 +663,9 @@ func (r *ResourceSubroutine) updateOciRepo(ctx context.Context, inst *unstructur
 		return subroutineslib.OK(), err
 	}
 
-	url = strings.TrimPrefix(url, "oci://")
-
+	if i := strings.Index(url, "://"); i >= 0 {
+		url = url[i+3:]
+	}
 	url = "oci://" + url
 	url = strings.TrimSuffix(url, ":"+version)
 

--- a/pkg/subroutines/resource/subroutine.go
+++ b/pkg/subroutines/resource/subroutine.go
@@ -20,7 +20,7 @@ import (
 	"github.com/platform-mesh/platform-mesh-operator/api/v1alpha1"
 	"github.com/platform-mesh/platform-mesh-operator/internal/config"
 	"github.com/platform-mesh/platform-mesh-operator/internal/metrics"
-	"github.com/platform-mesh/platform-mesh-operator/pkg/ocm"
+	"github.com/platform-mesh/platform-mesh-operator/internal/ociref"
 	"github.com/platform-mesh/platform-mesh-operator/pkg/subroutines"
 )
 
@@ -410,7 +410,7 @@ func (r *ResourceSubroutine) resolveArgoCDSource(inst *unstructured.Unstructured
 		return "", "", "", fmt.Errorf("no helmRepository, repoUrl, or imageReference found")
 	}
 
-	repoURL, err = extractOCIRepoURL(imageRef)
+	repoURL, err = ociref.ExtractRepoURL(imageRef)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -422,17 +422,6 @@ func (r *ResourceSubroutine) resolveArgoCDSource(inst *unstructured.Unstructured
 	return repoURL, version, "oci", nil
 }
 
-func extractOCIRepoURL(imageRef string) (string, error) {
-	if i := strings.Index(imageRef, "://"); i >= 0 {
-		imageRef = imageRef[i+3:]
-	}
-	baseURL := strings.Split(imageRef, ":")[0]
-	lastSlash := strings.LastIndex(baseURL, "/")
-	if lastSlash == -1 {
-		return "", fmt.Errorf("invalid imageReference format: %s", imageRef)
-	}
-	return baseURL[:lastSlash], nil
-}
 
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
@@ -663,19 +652,11 @@ func (r *ResourceSubroutine) updateOciRepo(ctx context.Context, inst *unstructur
 		return subroutineslib.OK(), err
 	}
 
-	if i := strings.Index(url, "://"); i >= 0 {
-		url = url[i+3:]
-	}
-	url = "oci://" + url
-	url = strings.TrimSuffix(url, ":"+version)
-
-	spec, err := ocm.ParseRef(url)
+	url, err = ociref.NormalizeOCIURL(url, version)
 	if err != nil {
 		log.Error().Err(err).Str("url", url).Msg("Failed to parse Resource url")
 		return subroutineslib.OK(), err
 	}
-
-	url = fmt.Sprintf("%s://%s/%s", spec.Scheme, spec.Host, spec.Repository)
 
 	// Update or create oci repo
 	log.Info().Msg("Processing OCI Chart Resource")

--- a/pkg/subroutines/resource/subroutine_test.go
+++ b/pkg/subroutines/resource/subroutine_test.go
@@ -1056,32 +1056,6 @@ func (s *ResourceTestSuite) Test_resolveArgoCDSource_GitNoRef() {
 	s.Contains(err.Error(), "no ref, version, or commit found")
 }
 
-func Test_extractOCIRepoURL(t *testing.T) {
-	tests := []struct {
-		input   string
-		want    string
-		wantErr bool
-	}{
-		{"oci://registry.example.com/charts/mychart:1.0.0@sha256:abc", "registry.example.com/charts", false},
-		{"registry.example.com/org/charts/app:v2.0", "registry.example.com/org/charts", false},
-		{"noslash", "", true},
-	}
-	for _, tt := range tests {
-		got, err := extractOCIRepoURL(tt.input)
-		if tt.wantErr {
-			if err == nil {
-				t.Errorf("extractOCIRepoURL(%q) expected error", tt.input)
-			}
-		} else {
-			if err != nil {
-				t.Fatalf("extractOCIRepoURL(%q) error: %v", tt.input, err)
-			}
-			if got != tt.want {
-				t.Errorf("extractOCIRepoURL(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		}
-	}
-}
 
 func Test_firstNonEmpty(t *testing.T) {
 	if got := firstNonEmpty("", "", "c"); got != "c" {


### PR DESCRIPTION
The deploy/resource subroutines always assume HTTPS. In case of insecure registries (e.g. local setup), the registry addresses are wrong.

This PR makes it so that schemes are taken into consideration, and addresses cleaned up properly.